### PR TITLE
Device remove fix

### DIFF
--- a/examples/test3.rs
+++ b/examples/test3.rs
@@ -1,0 +1,35 @@
+extern crate blurz;
+
+use std::error::Error;
+use std::time::Duration;
+use std::thread;
+
+use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
+use blurz::bluetooth_device::BluetoothDevice as Device;
+use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySession;
+
+fn test2() -> Result<(), Box<Error>> {
+    let adapter: Adapter = try!(Adapter::init());
+    let session = try!(DiscoverySession::create_session(adapter.get_id()));
+    loop{
+        thread::sleep(Duration::from_millis(200));
+        try!(session.start_discovery());
+        thread::sleep(Duration::from_millis(800));
+        let devices = try!(adapter.get_device_list());
+
+        println!("{} device(s) found", devices.len());
+        'device_loop: for d in devices {
+            let device = Device::new(d.clone());
+            println!("{} {:?} {:?}", device.get_id(), device.get_alias(),device.get_rssi());
+            try!(adapter.remove_device(device.get_id()));
+        }
+        try!(session.stop_discovery());
+    }
+}
+
+fn main() {
+    match test2() {
+       Ok(_) => (),
+       Err(e) => println!("{:?}", e),
+   }
+}

--- a/examples/test3.rs
+++ b/examples/test3.rs
@@ -8,10 +8,11 @@ use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
 use blurz::bluetooth_device::BluetoothDevice as Device;
 use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySession;
 
-fn test2() -> Result<(), Box<Error>> {
+fn test3() -> Result<(), Box<Error>> {
     let adapter: Adapter = try!(Adapter::init());
-    let session = try!(DiscoverySession::create_session(adapter.get_id()));
+    try!(adapter.set_powered(true));
     loop{
+        let session = try!(DiscoverySession::create_session(adapter.get_id()));
         thread::sleep(Duration::from_millis(200));
         try!(session.start_discovery());
         thread::sleep(Duration::from_millis(800));
@@ -20,7 +21,7 @@ fn test2() -> Result<(), Box<Error>> {
         println!("{} device(s) found", devices.len());
         'device_loop: for d in devices {
             let device = Device::new(d.clone());
-            println!("{} {:?} {:?}", device.get_id(), device.get_alias(),device.get_rssi());
+            println!("{} {:?} {:?}", device.get_id(), device.get_address(),device.get_rssi());
             try!(adapter.remove_device(device.get_id()));
         }
         try!(session.stop_discovery());
@@ -28,7 +29,7 @@ fn test2() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    match test2() {
+    match test3() {
        Ok(_) => (),
        Err(e) => println!("{:?}", e),
    }

--- a/examples/test3.rs
+++ b/examples/test3.rs
@@ -11,7 +11,7 @@ use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySe
 fn test3() -> Result<(), Box<Error>> {
     let adapter: Adapter = try!(Adapter::init());
     try!(adapter.set_powered(true));
-    loop{
+    loop {
         let session = try!(DiscoverySession::create_session(adapter.get_id()));
         thread::sleep(Duration::from_millis(200));
         try!(session.start_discovery());

--- a/src/bluetooth_adapter.rs
+++ b/src/bluetooth_adapter.rs
@@ -1,6 +1,6 @@
 use bluetooth_device::BluetoothDevice;
 use bluetooth_utils;
-use dbus::{Path,MessageItem};
+use dbus::MessageItem;
 use rustc_serialize::hex::FromHex;
 use std::error::Error;
 
@@ -227,8 +227,6 @@ impl BluetoothAdapter {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n40
     pub fn remove_device(&self, device: String) -> Result<(), Box<Error>> {
-        let path:Path=device.into();
-        let message_item=MessageItem::ObjectPath(path);
-        self.call_method("RemoveDevice", Some([message_item]))
+        self.call_method("RemoveDevice", Some([MessageItem::ObjectPath(device.into())]))
     }
 }

--- a/src/bluetooth_adapter.rs
+++ b/src/bluetooth_adapter.rs
@@ -1,6 +1,6 @@
 use bluetooth_device::BluetoothDevice;
 use bluetooth_utils;
-use dbus::MessageItem;
+use dbus::{Path,MessageItem};
 use rustc_serialize::hex::FromHex;
 use std::error::Error;
 
@@ -227,6 +227,8 @@ impl BluetoothAdapter {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n40
     pub fn remove_device(&self, device: String) -> Result<(), Box<Error>> {
-        self.call_method("RemoveDevice", Some([device.into()]))
+        let path:Path=device.into();
+        let message_item=MessageItem::ObjectPath(path);
+        self.call_method("RemoveDevice", Some([message_item]))
     }
 }


### PR DESCRIPTION
Using object path in device remove. Before fix, string was used what generated exception during object removal. 