### PR TITLE
Update version number for previous breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blurz"
-version = "0.2.4"
+version = "0.3.0"
 description = "Bluetooth lib for Rust using blueZ/dbus"
 readme = "README.md"
 authors = ["Attila Dusnoki <adusnoki@inf.u-szeged.hu>"]


### PR DESCRIPTION
https://github.com/szeged/blurz/pull/8 added a parameter to some public method, so code built with 0.2.2 does not compile with 0.2.3. or 0.2.4. Please yank these two versions and republish with an appropriate version number.