### PR TITLE
Breaking changes: persistent dbus connections and configurable timeouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blurz"
-version = "0.3.0"
+version = "0.4.0"
 description = "Bluetooth lib for Rust using blueZ/dbus"
 readme = "README.md"
 authors = ["Attila Dusnoki <adusnoki@inf.u-szeged.hu>"]

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -2,11 +2,13 @@ extern crate blurz;
 
 use std::error::Error;
 
+use blurz::bluetooth_session::BluetoothSession as Session;
 use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
 use blurz::bluetooth_device::BluetoothDevice as Device;
 
 fn test() -> Result<(), Box<Error>> {
-    let adapter: Adapter = try!(Adapter::init());
+    let session = &Session::create_session().unwrap();
+    let adapter: Adapter = try!(Adapter::init(session));
     let device: Device = try!(adapter.get_first_device());
     println!("{:?}", device);
     Ok(())
@@ -14,7 +16,7 @@ fn test() -> Result<(), Box<Error>> {
 
 fn main() {
     match test() {
-         Ok(_) => (),
-         Err(e) => println!("{:?}", e),
-     }
+        Ok(_) => (),
+        Err(e) => println!("{:?}", e),
+    }
 }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -2,12 +2,12 @@ extern crate blurz;
 
 use std::error::Error;
 
-use blurz::bluetooth_session::BluetoothSession as Session;
 use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
 use blurz::bluetooth_device::BluetoothDevice as Device;
+use blurz::bluetooth_session::BluetoothSession as Session;
 
 fn test() -> Result<(), Box<Error>> {
-    let session = &Session::create_session().unwrap();
+    let session = &Session::create_session(None).unwrap();
     let adapter: Adapter = try!(Adapter::init(session));
     let device: Device = try!(adapter.get_first_device());
     println!("{:?}", device);

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -4,18 +4,20 @@ static BATTERY_SERVICE_UUID: &'static str = "0000180f-0000-1000-8000-00805f9b34f
 static COLOR_PICKER_SERVICE_UUID: &'static str = "00001812-0000-1000-8000-00805f9b34fb";
 
 use std::error::Error;
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
 use blurz::bluetooth_device::BluetoothDevice as Device;
-use blurz::bluetooth_gatt_service::BluetoothGATTService as Service;
+use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySession;
 use blurz::bluetooth_gatt_characteristic::BluetoothGATTCharacteristic as Characteristic;
 use blurz::bluetooth_gatt_descriptor::BluetoothGATTDescriptor as Descriptor;
-use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySession;
+use blurz::bluetooth_gatt_service::BluetoothGATTService as Service;
+use blurz::bluetooth_session::BluetoothSession as Session;
 
 fn test2() -> Result<(), Box<Error>> {
-    let adapter: Adapter = try!(Adapter::init());
+    let bt_session = &Session::create_session()?;
+    let adapter: Adapter = try!(Adapter::init(bt_session));
     let session = try!(DiscoverySession::create_session(adapter.get_id()));
     try!(session.start_discovery());
     //let mut devices = vec!();
@@ -32,15 +34,14 @@ fn test2() -> Result<(), Box<Error>> {
         return Err(Box::from("No device found"));
     }
     println!("{} device(s) found", devices.len());
-    let mut device: Device = Device::new("".to_string());
+    let mut device: Device = Device::new(bt_session, "".to_string());
     'device_loop: for d in devices {
-        device = Device::new(d.clone());
+        device = Device::new(bt_session, d.clone());
         println!("{} {:?}", device.get_id(), device.get_alias());
         let uuids = try!(device.get_uuids());
         println!("{:?}", uuids);
         'uuid_loop: for uuid in uuids {
-            if uuid == COLOR_PICKER_SERVICE_UUID ||
-               uuid == BATTERY_SERVICE_UUID {
+            if uuid == COLOR_PICKER_SERVICE_UUID || uuid == BATTERY_SERVICE_UUID {
                 println!("{:?} has a service!", device.get_alias());
                 println!("connect device...");
                 device.connect().ok();
@@ -66,20 +67,19 @@ fn test2() -> Result<(), Box<Error>> {
     }
     let services = try!(device.get_gatt_services());
     for service in services {
-        let s = Service::new(service.clone());
+        let s = Service::new(bt_session, service.clone());
         println!("{:?}", s);
         let characteristics = try!(s.get_gatt_characteristics());
         for characteristic in characteristics {
-            let c = Characteristic::new(characteristic.clone());
+            let c = Characteristic::new(bt_session, characteristic.clone());
             println!("{:?}", c);
             println!("Value: {:?}", c.read_value(None));
             let descriptors = try!(c.get_gatt_descriptors());
             for descriptor in descriptors {
-                let d = Descriptor::new(descriptor.clone());
+                let d = Descriptor::new(bt_session, descriptor.clone());
                 println!("{:?}", d);
                 println!("Value: {:?}", d.read_value(None));
             }
-
         }
     }
     try!(device.disconnect());
@@ -88,7 +88,7 @@ fn test2() -> Result<(), Box<Error>> {
 
 fn main() {
     match test2() {
-         Ok(_) => (),
-         Err(e) => println!("{:?}", e),
-     }
+        Ok(_) => (),
+        Err(e) => println!("{:?}", e),
+    }
 }

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -16,9 +16,12 @@ use blurz::bluetooth_gatt_service::BluetoothGATTService as Service;
 use blurz::bluetooth_session::BluetoothSession as Session;
 
 fn test2() -> Result<(), Box<Error>> {
-    let bt_session = &Session::create_session()?;
+    let bt_session = &Session::create_session(None)?;
     let adapter: Adapter = try!(Adapter::init(bt_session));
-    let session = try!(DiscoverySession::create_session(adapter.get_id()));
+    let session = try!(DiscoverySession::create_session(
+        &bt_session,
+        adapter.get_id()
+    ));
     try!(session.start_discovery());
     //let mut devices = vec!();
     for _ in 0..5 {
@@ -44,7 +47,7 @@ fn test2() -> Result<(), Box<Error>> {
             if uuid == COLOR_PICKER_SERVICE_UUID || uuid == BATTERY_SERVICE_UUID {
                 println!("{:?} has a service!", device.get_alias());
                 println!("connect device...");
-                device.connect().ok();
+                device.connect(10000).ok();
                 if try!(device.is_connected()) {
                     println!("checking gatt...");
                     // We need to wait a bit after calling connect to safely

--- a/examples/test3.rs
+++ b/examples/test3.rs
@@ -1,15 +1,17 @@
 extern crate blurz;
 
 use std::error::Error;
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
 use blurz::bluetooth_device::BluetoothDevice as Device;
 use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySession;
+use blurz::bluetooth_session::BluetoothSession as Session;
 
 fn test3() -> Result<(), Box<Error>> {
-    let adapter: Adapter = try!(Adapter::init());
+    let bt_session = &Session::create_session()?;
+    let adapter: Adapter = try!(Adapter::init(bt_session));
     try!(adapter.set_powered(true));
     loop {
         let session = try!(DiscoverySession::create_session(adapter.get_id()));
@@ -20,8 +22,13 @@ fn test3() -> Result<(), Box<Error>> {
 
         println!("{} device(s) found", devices.len());
         'device_loop: for d in devices {
-            let device = Device::new(d.clone());
-            println!("{} {:?} {:?}", device.get_id(), device.get_address(),device.get_rssi());
+            let device = Device::new(bt_session, d.clone());
+            println!(
+                "{} {:?} {:?}",
+                device.get_id(),
+                device.get_address(),
+                device.get_rssi()
+            );
             try!(adapter.remove_device(device.get_id()));
         }
         try!(session.stop_discovery());
@@ -30,7 +37,7 @@ fn test3() -> Result<(), Box<Error>> {
 
 fn main() {
     match test3() {
-       Ok(_) => (),
-       Err(e) => println!("{:?}", e),
-   }
+        Ok(_) => (),
+        Err(e) => println!("{:?}", e),
+    }
 }

--- a/examples/test3.rs
+++ b/examples/test3.rs
@@ -10,11 +10,14 @@ use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySe
 use blurz::bluetooth_session::BluetoothSession as Session;
 
 fn test3() -> Result<(), Box<Error>> {
-    let bt_session = &Session::create_session()?;
+    let bt_session = &Session::create_session(None)?;
     let adapter: Adapter = try!(Adapter::init(bt_session));
     try!(adapter.set_powered(true));
     loop {
-        let session = try!(DiscoverySession::create_session(adapter.get_id()));
+        let session = try!(DiscoverySession::create_session(
+            &bt_session,
+            adapter.get_id()
+        ));
         thread::sleep(Duration::from_millis(200));
         try!(session.start_discovery());
         thread::sleep(Duration::from_millis(800));

--- a/examples/test4.rs
+++ b/examples/test4.rs
@@ -14,7 +14,7 @@ use blurz::bluetooth_obex::{
 use blurz::bluetooth_session::BluetoothSession as Session;
 
 fn test_obex_file_transfer() -> Result<(), Box<Error>> {
-    let session = &Session::create_session()?;
+    let session = &Session::create_session(None)?;
     let adapter: Adapter = Adapter::init(session)?;
     let devices: Vec<String> = adapter.get_device_list()?;
 
@@ -23,8 +23,7 @@ fn test_obex_file_transfer() -> Result<(), Box<Error>> {
         .filter(|&device_id| {
             let device = Device::new(session, device_id.to_string());
             device.is_ready_to_receive().unwrap()
-        })
-        .cloned()
+        }).cloned()
         .collect::<Vec<String>>();
 
     let device_id: &str = &filtered_devices[0];

--- a/examples/test4.rs
+++ b/examples/test4.rs
@@ -8,28 +8,29 @@ use std::path::Path;
 
 use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
 use blurz::bluetooth_device::BluetoothDevice as Device;
-use blurz::bluetooth_obex::open_bus_connection;
 use blurz::bluetooth_obex::{
     BluetoothOBEXSession as OBEXSession, BluetoothOBEXTransfer as OBEXTransfer,
 };
+use blurz::bluetooth_session::BluetoothSession as Session;
 
 fn test_obex_file_transfer() -> Result<(), Box<Error>> {
-    let adapter: Adapter = Adapter::init()?;
+    let session = &Session::create_session()?;
+    let adapter: Adapter = Adapter::init(session)?;
     let devices: Vec<String> = adapter.get_device_list()?;
 
     let filtered_devices = devices
         .iter()
         .filter(|&device_id| {
-            let device = Device::new(device_id.to_string());
+            let device = Device::new(session, device_id.to_string());
             device.is_ready_to_receive().unwrap()
-        }).cloned()
+        })
+        .cloned()
         .collect::<Vec<String>>();
 
     let device_id: &str = &filtered_devices[0];
-    let device = Device::new(device_id.to_string());
+    let device = Device::new(session, device_id.to_string());
 
-    let connection = open_bus_connection()?;
-    let session = OBEXSession::new(connection, &device)?;
+    let session = OBEXSession::new(session, &device)?;
 
     let mut empty_file = File::create("./test.png")?;
     empty_file.write_all(b"1111")?;

--- a/examples/test5.rs
+++ b/examples/test5.rs
@@ -1,0 +1,22 @@
+extern crate blurz;
+
+use std::error::Error;
+
+use blurz::bluetooth_event::BluetoothEvent;
+use blurz::bluetooth_session::BluetoothSession as Session;
+
+fn test5() -> Result<(), Box<Error>> {
+    let session = &Session::create_session(Some("/org/bluez/hci0")).unwrap();
+    loop {
+        for event in session.incoming(1000).map(BluetoothEvent::from) {
+            println!("{:?}", event);
+        }
+    }
+}
+
+fn main() {
+    match test5() {
+        Ok(_) => (),
+        Err(e) => println!("{:?}", e),
+    }
+}

--- a/src/bluetooth_adapter.rs
+++ b/src/bluetooth_adapter.rs
@@ -74,7 +74,7 @@ impl<'a> BluetoothAdapter<'a> {
         )
     }
 
-    fn set_property<T>(&self, prop: &str, value: T) -> Result<(), Box<Error>>
+    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<Error>>
     where
         T: Into<MessageItem>,
     {
@@ -84,16 +84,23 @@ impl<'a> BluetoothAdapter<'a> {
             &self.object_path,
             prop,
             value,
+            timeout_ms,
         )
     }
 
-    fn call_method(&self, method: &str, param: Option<&[MessageItem]>) -> Result<(), Box<Error>> {
+    fn call_method(
+        &self,
+        method: &str,
+        param: Option<&[MessageItem]>,
+        timeout_ms: i32,
+    ) -> Result<(), Box<Error>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             ADAPTER_INTERFACE,
             &self.object_path,
             method,
             param,
+            timeout_ms,
         )
     }
 
@@ -121,7 +128,7 @@ impl<'a> BluetoothAdapter<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n120
     pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
-        self.set_property("Alias", value)
+        self.set_property("Alias", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n139
@@ -138,7 +145,7 @@ impl<'a> BluetoothAdapter<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n147
     pub fn set_powered(&self, value: bool) -> Result<(), Box<Error>> {
-        self.set_property("Powered", value)
+        self.set_property("Powered", value, 10000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n156
@@ -149,7 +156,7 @@ impl<'a> BluetoothAdapter<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n156
     pub fn set_discoverable(&self, value: bool) -> Result<(), Box<Error>> {
-        self.set_property("Discoverable", value)
+        self.set_property("Discoverable", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n176
@@ -160,7 +167,7 @@ impl<'a> BluetoothAdapter<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n176
     pub fn set_pairable(&self, value: bool) -> Result<(), Box<Error>> {
-        self.set_property("Pairable", value)
+        self.set_property("Pairable", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n187
@@ -171,7 +178,7 @@ impl<'a> BluetoothAdapter<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n187
     pub fn set_pairable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
-        self.set_property("PairableTimeout", value)
+        self.set_property("PairableTimeout", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n196
@@ -182,7 +189,7 @@ impl<'a> BluetoothAdapter<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n196
     pub fn set_discoverable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
-        self.set_property("DiscoverableTimeout", value)
+        self.set_property("DiscoverableTimeout", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n205
@@ -260,6 +267,7 @@ impl<'a> BluetoothAdapter<'a> {
         self.call_method(
             "RemoveDevice",
             Some(&[MessageItem::ObjectPath(device.into())]),
+            1000,
         )
     }
 }

--- a/src/bluetooth_device.rs
+++ b/src/bluetooth_device.rs
@@ -275,8 +275,8 @@ impl<'a> BluetoothDevice<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n12
-    pub fn connect(&self) -> Result<(), Box<Error>> {
-        self.call_method("Connect", None, 30000)
+    pub fn connect(&self, timeout_ms: i32) -> Result<(), Box<Error>> {
+        self.call_method("Connect", None, timeout_ms)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n29

--- a/src/bluetooth_device.rs
+++ b/src/bluetooth_device.rs
@@ -34,7 +34,7 @@ impl<'a> BluetoothDevice<'a> {
         )
     }
 
-    fn set_property<T>(&self, prop: &str, value: T) -> Result<(), Box<Error>>
+    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<Error>>
     where
         T: Into<MessageItem>,
     {
@@ -44,16 +44,23 @@ impl<'a> BluetoothDevice<'a> {
             &self.object_path,
             prop,
             value,
+            timeout_ms,
         )
     }
 
-    fn call_method(&self, method: &str, param: Option<&[MessageItem]>) -> Result<(), Box<Error>> {
+    fn call_method(
+        &self,
+        method: &str,
+        param: Option<&[MessageItem]>,
+        timeout_ms: i32,
+    ) -> Result<(), Box<Error>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             DEVICE_INTERFACE,
             &self.object_path,
             method,
             param,
+            timeout_ms,
         )
     }
 
@@ -127,7 +134,7 @@ impl<'a> BluetoothDevice<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n149
     pub fn set_trusted(&self, value: bool) -> Result<(), Box<Error>> {
-        self.set_property("Trusted", value)
+        self.set_property("Trusted", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n149
@@ -150,7 +157,7 @@ impl<'a> BluetoothDevice<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n161
     pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
-        self.set_property("Alias", value)
+        self.set_property("Alias", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n174
@@ -269,31 +276,31 @@ impl<'a> BluetoothDevice<'a> {
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n12
     pub fn connect(&self) -> Result<(), Box<Error>> {
-        self.call_method("Connect", None)
+        self.call_method("Connect", None, 30000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n29
     pub fn disconnect(&self) -> Result<(), Box<Error>> {
-        self.call_method("Disconnect", None)
+        self.call_method("Disconnect", None, 5000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n43
     pub fn connect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
-        self.call_method("ConnectProfile", Some(&[uuid.into()]))
+        self.call_method("ConnectProfile", Some(&[uuid.into()]), 30000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n55
     pub fn disconnect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
-        self.call_method("DisconnectProfile", Some(&[uuid.into()]))
+        self.call_method("DisconnectProfile", Some(&[uuid.into()]), 5000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n70
     pub fn pair(&self) -> Result<(), Box<Error>> {
-        self.call_method("Pair", None)
+        self.call_method("Pair", None, 60000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n97
     pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
-        self.call_method("CancelPairing", None)
+        self.call_method("CancelPairing", None, 5000)
     }
 }

--- a/src/bluetooth_device.rs
+++ b/src/bluetooth_device.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 
 static DEVICE_INTERFACE: &'static str = "org.bluez.Device1";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BluetoothDevice<'a> {
     object_path: String,
     session: &'a BluetoothSession,

--- a/src/bluetooth_discovery_session.rs
+++ b/src/bluetooth_discovery_session.rs
@@ -1,5 +1,5 @@
 use bluetooth_session::BluetoothSession;
-use dbus::{BusType, Connection, Message, MessageItem};
+use dbus::{Message, MessageItem};
 use std::error::Error;
 
 static ADAPTER_INTERFACE: &'static str = "org.bluez.Adapter1";

--- a/src/bluetooth_discovery_session.rs
+++ b/src/bluetooth_discovery_session.rs
@@ -1,34 +1,46 @@
+use bluetooth_session::BluetoothSession;
 use dbus::{BusType, Connection, Message, MessageItem};
 use std::error::Error;
 
 static ADAPTER_INTERFACE: &'static str = "org.bluez.Adapter1";
 static SERVICE_NAME: &'static str = "org.bluez";
 
-pub struct BluetoothDiscoverySession {
+pub struct BluetoothDiscoverySession<'a> {
     adapter: String,
-    connection: Connection,
+    session: &'a BluetoothSession,
 }
 
-impl BluetoothDiscoverySession {
-    pub fn create_session(adapter: String) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let c = try!(Connection::get_private(BusType::System));
-        Ok(BluetoothDiscoverySession::new(adapter, c))
+impl<'a> BluetoothDiscoverySession<'a> {
+    pub fn create_session(
+        session: &'a BluetoothSession,
+        adapter: String,
+    ) -> Result<BluetoothDiscoverySession, Box<Error>> {
+        Ok(BluetoothDiscoverySession::new(session, adapter))
     }
 
-    fn new(adapter: String, connection: Connection) -> BluetoothDiscoverySession {
+    fn new(session: &'a BluetoothSession, adapter: String) -> BluetoothDiscoverySession<'a> {
         BluetoothDiscoverySession {
             adapter: adapter,
-            connection: connection,
+            session: session,
         }
     }
 
     fn call_method(&self, method: &str, param: Option<[MessageItem; 1]>) -> Result<(), Box<Error>> {
-        let mut m = try!(Message::new_method_call(SERVICE_NAME, &self.adapter, ADAPTER_INTERFACE, method));
+        let mut m = try!(Message::new_method_call(
+            SERVICE_NAME,
+            &self.adapter,
+            ADAPTER_INTERFACE,
+            method
+        ));
         match param {
             Some(p) => m.append_items(&p),
             None => (),
         };
-        try!(self.connection.send_with_reply_and_block(m, 1000));
+        try!(
+            self.session
+                .get_connection()
+                .send_with_reply_and_block(m, 1000)
+        );
         Ok(())
     }
 

--- a/src/bluetooth_discovery_session.rs
+++ b/src/bluetooth_discovery_session.rs
@@ -4,7 +4,6 @@ use std::error::Error;
 static ADAPTER_INTERFACE: &'static str = "org.bluez.Adapter1";
 static SERVICE_NAME: &'static str = "org.bluez";
 
-#[derive(Debug)]
 pub struct BluetoothDiscoverySession {
     adapter: String,
     connection: Connection,

--- a/src/bluetooth_discovery_session.rs
+++ b/src/bluetooth_discovery_session.rs
@@ -1,5 +1,5 @@
 use bluetooth_session::BluetoothSession;
-use dbus::{Message, MessageItem};
+use dbus::{Message, MessageItem, MessageItemArray, Signature};
 use std::error::Error;
 
 static ADAPTER_INTERFACE: &'static str = "org.bluez.Adapter1";
@@ -50,5 +50,48 @@ impl<'a> BluetoothDiscoverySession<'a> {
 
     pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
         self.call_method("StopDiscovery", None)
+    }
+
+    pub fn set_discovery_filter(
+        &self,
+        uuids: Vec<String>,
+        rssi: Option<i16>,
+        pathloss: Option<u16>,
+    ) -> Result<(), Box<Error>> {
+        let uuids = {
+            let mut res: Vec<MessageItem> = Vec::new();
+            for u in uuids {
+                res.push(u.into());
+            }
+            res
+        };
+
+        let mut m = vec![MessageItem::DictEntry(
+            Box::new("UUIDs".into()),
+            Box::new(MessageItem::Variant(Box::new(
+                MessageItem::new_array(uuids).unwrap(),
+            ))),
+        )];
+
+        if let Some(rssi) = rssi {
+            m.push(MessageItem::DictEntry(
+                Box::new("RSSI".into()),
+                Box::new(MessageItem::Variant(Box::new(rssi.into()))),
+            ))
+        }
+
+        if let Some(pathloss) = pathloss {
+            m.push(MessageItem::DictEntry(
+                Box::new("Pathloss".into()),
+                Box::new(MessageItem::Variant(Box::new(pathloss.into()))),
+            ))
+        }
+
+        self.call_method(
+            "SetDiscoveryFilter",
+            Some([MessageItem::Array(
+                MessageItemArray::new(m, Signature::from("a{sv}")).unwrap(),
+            )]),
+        )
     }
 }

--- a/src/bluetooth_event.rs
+++ b/src/bluetooth_event.rs
@@ -23,6 +23,10 @@ pub enum BluetoothEvent {
         object_path: String,
         value: Box<[u8]>,
     },
+    RSSI {
+        object_path: String,
+        rssi: i16,
+    },
     None,
 }
 
@@ -86,6 +90,17 @@ impl BluetoothEvent {
                         let event = BluetoothEvent::Value {
                             object_path: object_path.clone(),
                             value: value.clone().into_boxed_slice(),
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                if let Some(value) = properties.get("RSSI") {
+                    if let Some(rssi) = cast::<i16>(&value.0) {
+                        let event = BluetoothEvent::RSSI {
+                            object_path: object_path.clone(),
+                            rssi: *rssi,
                         };
 
                         return Some(event);

--- a/src/bluetooth_event.rs
+++ b/src/bluetooth_event.rs
@@ -1,0 +1,100 @@
+use dbus::{arg::cast, arg::RefArg, arg::TypeMismatchError, arg::Variant, Message};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug)]
+pub enum BluetoothEvent {
+    Powered {
+        object_path: String,
+        powered: bool,
+    },
+    Discovering {
+        object_path: String,
+        discovering: bool,
+    },
+    Connected {
+        object_path: String,
+        connected: bool,
+    },
+    ServicesResolved {
+        object_path: String,
+        services_resolved: bool,
+    },
+    Value {
+        object_path: String,
+        value: Box<[u8]>,
+    },
+    None,
+}
+
+impl BluetoothEvent {
+    pub fn from(conn_msg: Message) -> Option<BluetoothEvent> {
+        let result: Result<
+            (&str, HashMap<String, Variant<Box<RefArg>>>),
+            TypeMismatchError,
+        > = conn_msg.read2();
+
+        match result {
+            Ok((_, properties)) => {
+                let object_path = conn_msg.path().unwrap().to_string();
+
+                if let Some(value) = properties.get("Powered") {
+                    if let Some(powered) = cast::<bool>(&value.0) {
+                        let event = BluetoothEvent::Powered {
+                            object_path: object_path.clone(),
+                            powered: *powered,
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                if let Some(value) = properties.get("Discovering") {
+                    if let Some(discovering) = cast::<bool>(&value.0) {
+                        let event = BluetoothEvent::Discovering {
+                            object_path: object_path.clone(),
+                            discovering: *discovering,
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                if let Some(value) = properties.get("Connected") {
+                    if let Some(connected) = cast::<bool>(&value.0) {
+                        let event = BluetoothEvent::Connected {
+                            object_path: object_path.clone(),
+                            connected: *connected,
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                if let Some(value) = properties.get("ServicesResolved") {
+                    if let Some(services_resolved) = cast::<bool>(&value.0) {
+                        let event = BluetoothEvent::ServicesResolved {
+                            object_path: object_path.clone(),
+                            services_resolved: *services_resolved,
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                if let Some(value) = properties.get("Value") {
+                    if let Some(value) = cast::<Vec<u8>>(&value.0) {
+                        let event = BluetoothEvent::Value {
+                            object_path: object_path.clone(),
+                            value: value.clone().into_boxed_slice(),
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                Some(BluetoothEvent::None)
+            }
+            Err(_err) => None,
+        }
+    }
+}

--- a/src/bluetooth_gatt_characteristic.rs
+++ b/src/bluetooth_gatt_characteristic.rs
@@ -34,13 +34,19 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
         )
     }
 
-    fn call_method(&self, method: &str, param: Option<&[MessageItem]>) -> Result<(), Box<Error>> {
+    fn call_method(
+        &self,
+        method: &str,
+        param: Option<&[MessageItem]>,
+        timeout_ms: i32,
+    ) -> Result<(), Box<Error>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             GATT_CHARACTERISTIC_INTERFACE,
             &self.object_path,
             method,
             param,
+            timeout_ms,
         )
     }
 
@@ -154,17 +160,18 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
                     ).unwrap(),
                 ),
             ]),
+            10000,
         )
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n96
     pub fn start_notify(&self) -> Result<(), Box<Error>> {
-        self.call_method("StartNotify", None)
+        self.call_method("StartNotify", None, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n105
     pub fn stop_notify(&self) -> Result<(), Box<Error>> {
-        self.call_method("StopNotify", None)
+        self.call_method("StopNotify", None, 1000)
     }
 
     pub fn acquire_notify(&self) -> Result<(OwnedFd, u16), Box<Error>> {

--- a/src/bluetooth_gatt_characteristic.rs
+++ b/src/bluetooth_gatt_characteristic.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 static SERVICE_NAME: &'static str = "org.bluez";
 static GATT_CHARACTERISTIC_INTERFACE: &'static str = "org.bluez.GattCharacteristic1";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BluetoothGATTCharacteristic<'a> {
     object_path: String,
     session: &'a BluetoothSession,

--- a/src/bluetooth_gatt_descriptor.rs
+++ b/src/bluetooth_gatt_descriptor.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 static SERVICE_NAME: &'static str = "org.bluez";
 static GATT_DESCRIPTOR_INTERFACE: &'static str = "org.bluez.GattDescriptor1";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BluetoothGATTDescriptor<'a> {
     object_path: String,
     session: &'a BluetoothSession,

--- a/src/bluetooth_gatt_descriptor.rs
+++ b/src/bluetooth_gatt_descriptor.rs
@@ -34,13 +34,19 @@ impl<'a> BluetoothGATTDescriptor<'a> {
         )
     }
 
-    fn call_method(&self, method: &str, param: Option<&[MessageItem]>) -> Result<(), Box<Error>> {
+    fn call_method(
+        &self,
+        method: &str,
+        param: Option<&[MessageItem]>,
+        timeout_ms: i32,
+    ) -> Result<(), Box<Error>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             GATT_DESCRIPTOR_INTERFACE,
             &self.object_path,
             method,
             param,
+            timeout_ms,
         )
     }
 
@@ -143,6 +149,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
                     ).unwrap(),
                 ),
             ]),
+            1000,
         )
     }
 }

--- a/src/bluetooth_gatt_descriptor.rs
+++ b/src/bluetooth_gatt_descriptor.rs
@@ -1,21 +1,23 @@
-use dbus::{Connection, BusType, Message, MessageItem, MessageItemArray, Signature};
+use bluetooth_session::BluetoothSession;
 use bluetooth_utils;
+use dbus::{BusType, Connection, Message, MessageItem, MessageItemArray, Signature};
 
 use std::error::Error;
 
 static SERVICE_NAME: &'static str = "org.bluez";
 static GATT_DESCRIPTOR_INTERFACE: &'static str = "org.bluez.GattDescriptor1";
 
-#[derive(Clone, Debug)]
-pub struct BluetoothGATTDescriptor {
+#[derive(Clone)]
+pub struct BluetoothGATTDescriptor<'a> {
     object_path: String,
+    session: &'a BluetoothSession,
 }
 
-impl BluetoothGATTDescriptor {
-    pub fn new(object_path: String)
-           -> BluetoothGATTDescriptor {
+impl<'a> BluetoothGATTDescriptor<'a> {
+    pub fn new(session: &'a BluetoothSession, object_path: String) -> BluetoothGATTDescriptor {
         BluetoothGATTDescriptor {
-            object_path: object_path
+            object_path: object_path,
+            session: session,
         }
     }
 
@@ -24,16 +26,27 @@ impl BluetoothGATTDescriptor {
     }
 
     fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
-        bluetooth_utils::get_property(GATT_DESCRIPTOR_INTERFACE, &self.object_path, prop)
+        bluetooth_utils::get_property(
+            self.session.get_connection(),
+            GATT_DESCRIPTOR_INTERFACE,
+            &self.object_path,
+            prop,
+        )
     }
 
     fn call_method(&self, method: &str, param: Option<&[MessageItem]>) -> Result<(), Box<Error>> {
-        bluetooth_utils::call_method(GATT_DESCRIPTOR_INTERFACE, &self.object_path, method, param)
+        bluetooth_utils::call_method(
+            self.session.get_connection(),
+            GATT_DESCRIPTOR_INTERFACE,
+            &self.object_path,
+            method,
+            param,
+        )
     }
 
-/*
- * Properties
- */
+    /*
+     * Properties
+     */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n198
     pub fn get_uuid(&self) -> Result<String, Box<Error>> {
@@ -69,25 +82,31 @@ impl BluetoothGATTDescriptor {
         Ok(v)
     }
 
-/*
- * Methods
- */
+    /*
+     * Methods
+     */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n174
     pub fn read_value(&self, offset: Option<u16>) -> Result<Vec<u8>, Box<Error>> {
         let c = try!(Connection::get_private(BusType::System));
-        let mut m = try!(Message::new_method_call(SERVICE_NAME, &self.object_path, GATT_DESCRIPTOR_INTERFACE, "ReadValue"));
-        m.append_items(&[
-            MessageItem::Array(
-                MessageItemArray::new(
-                    match offset {
-                        Some(o) => vec![MessageItem::DictEntry(Box::new("offset".into()),
-                                        Box::new(MessageItem::Variant(Box::new(o.into()))))],
-                        None => vec![]
-                    }, Signature::from("a{sv}")
-                ).unwrap()
-            )
-        ]);
+        let mut m = try!(Message::new_method_call(
+            SERVICE_NAME,
+            &self.object_path,
+            GATT_DESCRIPTOR_INTERFACE,
+            "ReadValue"
+        ));
+        m.append_items(&[MessageItem::Array(
+            MessageItemArray::new(
+                match offset {
+                    Some(o) => vec![MessageItem::DictEntry(
+                        Box::new("offset".into()),
+                        Box::new(MessageItem::Variant(Box::new(o.into()))),
+                    )],
+                    None => vec![],
+                },
+                Signature::from("a{sv}"),
+            ).unwrap(),
+        )]);
         let reply = try!(c.send_with_reply_and_block(m, 1000));
         let items: MessageItem = reply.get1().unwrap();
         let z: &[MessageItem] = items.inner().unwrap();
@@ -107,17 +126,23 @@ impl BluetoothGATTDescriptor {
             }
             res
         };
-        self.call_method("WriteValue", Some(&[
-            MessageItem::new_array(args).unwrap(),
-            MessageItem::Array(
-                MessageItemArray::new(
-                    match offset {
-                        Some(o) => vec![MessageItem::DictEntry(Box::new("offset".into()),
-                                        Box::new(MessageItem::Variant(Box::new(o.into()))))],
-                        None => vec![]
-                    }, Signature::from("a{sv}")
-                ).unwrap()
-            )
-        ]))
+        self.call_method(
+            "WriteValue",
+            Some(&[
+                MessageItem::new_array(args).unwrap(),
+                MessageItem::Array(
+                    MessageItemArray::new(
+                        match offset {
+                            Some(o) => vec![MessageItem::DictEntry(
+                                Box::new("offset".into()),
+                                Box::new(MessageItem::Variant(Box::new(o.into()))),
+                            )],
+                            None => vec![],
+                        },
+                        Signature::from("a{sv}"),
+                    ).unwrap(),
+                ),
+            ]),
+        )
     }
 }

--- a/src/bluetooth_gatt_service.rs
+++ b/src/bluetooth_gatt_service.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 
 static GATT_SERVICE_INTERFACE: &'static str = "org.bluez.GattService1";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BluetoothGATTService<'a> {
     object_path: String,
     session: &'a BluetoothSession,

--- a/src/bluetooth_obex.rs
+++ b/src/bluetooth_obex.rs
@@ -80,7 +80,9 @@ impl<'a> BluetoothOBEXSession<'a> {
         let m = Message::new_method_call(OBEX_BUS, OBEX_PATH, CLIENT_INTERFACE, "CreateSession")?
             .append2(device_address, args);
 
-        let r = session.get_connection().send_with_reply_and_block(m, 1000)?;
+        let r = session
+            .get_connection()
+            .send_with_reply_and_block(m, 1000)?;
         let session_path: ObjectPath = r.read1()?;
         let session_str: String = session_path.parse()?;
         let obex_session = BluetoothOBEXSession {
@@ -106,7 +108,7 @@ impl<'a> BluetoothOBEXSession<'a> {
 pub struct BluetoothOBEXTransfer<'a> {
     session: &'a BluetoothOBEXSession<'a>,
     object_path: String,
-    name: String,
+    _name: String,
 }
 
 impl<'a> BluetoothOBEXTransfer<'a> {
@@ -116,8 +118,9 @@ impl<'a> BluetoothOBEXTransfer<'a> {
         file_path: &str,
     ) -> Result<BluetoothOBEXTransfer<'a>, Box<Error>> {
         let session_path: String = session.object_path.clone();
-        let m = Message::new_method_call(OBEX_BUS, session_path, OBJECT_PUSH_INTERFACE, "SendFile")?
-            .append1(file_path);
+        let m =
+            Message::new_method_call(OBEX_BUS, session_path, OBJECT_PUSH_INTERFACE, "SendFile")?
+                .append1(file_path);
         let r = session
             .session
             .get_connection()
@@ -133,7 +136,7 @@ impl<'a> BluetoothOBEXTransfer<'a> {
         let obex_transfer = BluetoothOBEXTransfer {
             session,
             object_path: transfer_str,
-            name: file_name,
+            _name: file_name,
         };
         Ok(obex_transfer)
     }

--- a/src/bluetooth_session.rs
+++ b/src/bluetooth_session.rs
@@ -1,35 +1,117 @@
-use dbus::{arg::cast, arg::RefArg, arg::TypeMismatchError, arg::Variant, BusType, Connection};
+use dbus::{
+    arg::cast, arg::RefArg, arg::TypeMismatchError, arg::Variant, BusType, ConnMsgs, Connection,
+    Message,
+};
 use std::collections::HashMap;
 use std::error::Error;
 
-use bluetooth_adapter::BluetoothAdapter;
-use bluetooth_device::BluetoothDevice;
-
-use std::sync::mpsc;
-
-static BLUEZ_MATCH: &'static str = "sender='org.bluez'";
+static BLUEZ_MATCH: &'static str = "type='signal',sender='org.bluez'";
 
 pub struct BluetoothSession {
     connection: Connection,
-    powered_callback: Option<Box<Fn(BluetoothAdapter, &bool)>>,
-    discovering_callback: Option<Box<Fn(BluetoothAdapter, &bool)>>,
-    connected_callback: Option<Box<Fn(BluetoothDevice, &bool)>>,
-    services_resolved_callback: Option<Box<Fn(BluetoothDevice, &bool)>>,
+}
+
+#[derive(Clone)]
+pub enum BluetoothEvent {
+    Powered {
+        object_path: String,
+        powered: bool,
+    },
+    Discovering {
+        object_path: String,
+        discovering: bool,
+    },
+    Connected {
+        object_path: String,
+        connected: bool,
+    },
+    ServicesResolved {
+        object_path: String,
+        services_resolved: bool,
+    },
+    None,
+}
+
+impl BluetoothEvent {
+    pub fn from(conn_msg: Message) -> Option<BluetoothEvent> {
+        let result: Result<
+            (&str, HashMap<String, Variant<Box<RefArg>>>),
+            TypeMismatchError,
+        > = conn_msg.read2();
+
+        match result {
+            Ok((_, properties)) => {
+                let object_path = conn_msg.path().unwrap().to_string();
+
+                if let Some(value) = properties.get("Powered") {
+                    if let Some(powered) = cast::<bool>(&value.0) {
+                        let event = BluetoothEvent::Powered {
+                            object_path: object_path.clone(),
+                            powered: *powered,
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                if let Some(value) = properties.get("Discovering") {
+                    if let Some(discovering) = cast::<bool>(&value.0) {
+                        let event = BluetoothEvent::Discovering {
+                            object_path: object_path.clone(),
+                            discovering: *discovering,
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                if let Some(value) = properties.get("Connected") {
+                    if let Some(connected) = cast::<bool>(&value.0) {
+                        let event = BluetoothEvent::Connected {
+                            object_path: object_path.clone(),
+                            connected: *connected,
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                if let Some(value) = properties.get("ServicesResolved") {
+                    if let Some(services_resolved) = cast::<bool>(&value.0) {
+                        let event = BluetoothEvent::ServicesResolved {
+                            object_path: object_path.clone(),
+                            services_resolved: *services_resolved,
+                        };
+
+                        return Some(event);
+                    }
+                }
+
+                Some(BluetoothEvent::None)
+            }
+            Err(err) => None,
+        }
+    }
 }
 
 impl BluetoothSession {
-    pub fn create_session() -> Result<BluetoothSession, Box<Error>> {
+    pub fn create_session(path: Option<&str>) -> Result<BluetoothSession, Box<Error>> {
+        let mut rule = {
+            if let Some(path) = path {
+                format!("{},path='{}'", BLUEZ_MATCH, path)
+            } else {
+                String::from(BLUEZ_MATCH)
+            }
+        };
+
         let c = try!(Connection::get_private(BusType::System));
+        c.add_match(rule.as_str())?;
         Ok(BluetoothSession::new(c))
     }
 
     fn new(connection: Connection) -> BluetoothSession {
         BluetoothSession {
             connection: connection,
-            powered_callback: None,
-            discovering_callback: None,
-            connected_callback: None,
-            services_resolved_callback: None,
         }
     }
 
@@ -37,84 +119,9 @@ impl BluetoothSession {
         &self.connection
     }
 
-    pub fn set_powered_callback(&mut self, callback: Box<Fn(BluetoothAdapter, &bool)>) {
-        self.powered_callback = Some(callback);
-    }
-
-    pub fn set_discovering_callback(&mut self, callback: Box<Fn(BluetoothAdapter, &bool)>) {
-        self.discovering_callback = Some(callback);
-    }
-
-    pub fn set_connected_callback(&mut self, callback: Box<Fn(BluetoothDevice, &bool)>) {
-        self.connected_callback = Some(callback);
-    }
-
-    pub fn set_services_resolved_callback(&mut self, callback: Box<Fn(BluetoothDevice, &bool)>) {
-        self.services_resolved_callback = Some(callback);
-    }
-
-    pub fn listen(&mut self, terminate: mpsc::Receiver<bool>) -> Result<(), Box<Error>> {
-        self.connection.add_match(BLUEZ_MATCH)?;
-        loop {
-            for conn_msg in self.connection.incoming(1000) {
-                let result: Result<
-                    (&str, HashMap<String, Variant<Box<RefArg>>>),
-                    TypeMismatchError,
-                > = conn_msg.read2();
-
-                match result {
-                    Ok((_, properties)) => {
-                        let object_path = conn_msg.path().unwrap().to_string();
-
-                        if let Some(value) = properties.get("Powered") {
-                            if let Some(powered) = cast::<bool>(&value.0) {
-                                if let Some(ref callback) = self.powered_callback {
-                                    callback(
-                                        BluetoothAdapter::create_adapter(self, object_path.clone())
-                                            .unwrap(),
-                                        powered,
-                                    );
-                                }
-                            }
-                        }
-
-                        if let Some(value) = properties.get("Discovering") {
-                            if let Some(discovering) = cast::<bool>(&value.0) {
-                                if let Some(ref callback) = self.discovering_callback {
-                                    callback(
-                                        BluetoothAdapter::create_adapter(self, object_path.clone())
-                                            .unwrap(),
-                                        discovering,
-                                    );
-                                }
-                            }
-                        }
-
-                        if let Some(value) = properties.get("Connected") {
-                            if let Some(c) = cast::<bool>(&value.0) {
-                                if let Some(ref callback) = self.connected_callback {
-                                    callback(BluetoothDevice::new(self, object_path.clone()), c);
-                                }
-                            }
-                        }
-
-                        if let Some(value) = properties.get("ServicesResolved") {
-                            if let Some(s) = cast::<bool>(&value.0) {
-                                println!("{} services_resolved={}", conn_msg.path().unwrap(), s);
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            let t = terminate.try_recv();
-            match t {
-                Ok(true) => {
-                    return Ok(());
-                }
-                _ => {}
-            }
-        }
+    pub fn incoming(&self, timeout_ms: u32) -> ConnMsgs<&Connection> {
+        self.connection.incoming(timeout_ms)
     }
 }
+
+unsafe impl Send for BluetoothEvent {}

--- a/src/bluetooth_session.rs
+++ b/src/bluetooth_session.rs
@@ -1,0 +1,120 @@
+use dbus::{arg::cast, arg::RefArg, arg::TypeMismatchError, arg::Variant, BusType, Connection};
+use std::collections::HashMap;
+use std::error::Error;
+
+use bluetooth_adapter::BluetoothAdapter;
+use bluetooth_device::BluetoothDevice;
+
+use std::sync::mpsc;
+
+static BLUEZ_MATCH: &'static str = "sender='org.bluez'";
+
+pub struct BluetoothSession {
+    connection: Connection,
+    powered_callback: Option<Box<Fn(BluetoothAdapter, &bool)>>,
+    discovering_callback: Option<Box<Fn(BluetoothAdapter, &bool)>>,
+    connected_callback: Option<Box<Fn(BluetoothDevice, &bool)>>,
+    services_resolved_callback: Option<Box<Fn(BluetoothDevice, &bool)>>,
+}
+
+impl BluetoothSession {
+    pub fn create_session() -> Result<BluetoothSession, Box<Error>> {
+        let c = try!(Connection::get_private(BusType::System));
+        Ok(BluetoothSession::new(c))
+    }
+
+    fn new(connection: Connection) -> BluetoothSession {
+        BluetoothSession {
+            connection: connection,
+            powered_callback: None,
+            discovering_callback: None,
+            connected_callback: None,
+            services_resolved_callback: None,
+        }
+    }
+
+    pub fn get_connection(&self) -> &Connection {
+        &self.connection
+    }
+
+    pub fn set_powered_callback(&mut self, callback: Box<Fn(BluetoothAdapter, &bool)>) {
+        self.powered_callback = Some(callback);
+    }
+
+    pub fn set_discovering_callback(&mut self, callback: Box<Fn(BluetoothAdapter, &bool)>) {
+        self.discovering_callback = Some(callback);
+    }
+
+    pub fn set_connected_callback(&mut self, callback: Box<Fn(BluetoothDevice, &bool)>) {
+        self.connected_callback = Some(callback);
+    }
+
+    pub fn set_services_resolved_callback(&mut self, callback: Box<Fn(BluetoothDevice, &bool)>) {
+        self.services_resolved_callback = Some(callback);
+    }
+
+    pub fn listen(&mut self, terminate: mpsc::Receiver<bool>) -> Result<(), Box<Error>> {
+        self.connection.add_match(BLUEZ_MATCH)?;
+        loop {
+            for conn_msg in self.connection.incoming(1000) {
+                let result: Result<
+                    (&str, HashMap<String, Variant<Box<RefArg>>>),
+                    TypeMismatchError,
+                > = conn_msg.read2();
+
+                match result {
+                    Ok((_, properties)) => {
+                        let object_path = conn_msg.path().unwrap().to_string();
+
+                        if let Some(value) = properties.get("Powered") {
+                            if let Some(powered) = cast::<bool>(&value.0) {
+                                if let Some(ref callback) = self.powered_callback {
+                                    callback(
+                                        BluetoothAdapter::create_adapter(self, object_path.clone())
+                                            .unwrap(),
+                                        powered,
+                                    );
+                                }
+                            }
+                        }
+
+                        if let Some(value) = properties.get("Discovering") {
+                            if let Some(discovering) = cast::<bool>(&value.0) {
+                                if let Some(ref callback) = self.discovering_callback {
+                                    callback(
+                                        BluetoothAdapter::create_adapter(self, object_path.clone())
+                                            .unwrap(),
+                                        discovering,
+                                    );
+                                }
+                            }
+                        }
+
+                        if let Some(value) = properties.get("Connected") {
+                            if let Some(c) = cast::<bool>(&value.0) {
+                                if let Some(ref callback) = self.connected_callback {
+                                    callback(BluetoothDevice::new(self, object_path.clone()), c);
+                                }
+                            }
+                        }
+
+                        if let Some(value) = properties.get("ServicesResolved") {
+                            if let Some(s) = cast::<bool>(&value.0) {
+                                println!("{} services_resolved={}", conn_msg.path().unwrap(), s);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            let t = terminate.try_recv();
+            match t {
+                Ok(true) => {
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/bluetooth_session.rs
+++ b/src/bluetooth_session.rs
@@ -11,7 +11,7 @@ pub struct BluetoothSession {
 
 impl BluetoothSession {
     pub fn create_session(path: Option<&str>) -> Result<BluetoothSession, Box<Error>> {
-        let mut rule = {
+        let rule = {
             if let Some(path) = path {
                 format!("{},path='{}'", BLUEZ_MATCH, path)
             } else {

--- a/src/bluetooth_utils.rs
+++ b/src/bluetooth_utils.rs
@@ -101,11 +101,12 @@ pub fn set_property<T>(
     object_path: &str,
     prop: &str,
     value: T,
+    timeout_ms: i32,
 ) -> Result<(), Box<Error>>
 where
     T: Into<MessageItem>,
 {
-    let p = Props::new(&c, SERVICE_NAME, object_path, interface, 1000);
+    let p = Props::new(&c, SERVICE_NAME, object_path, interface, timeout_ms);
     Ok(try!(p.set(prop, value.into())))
 }
 
@@ -115,6 +116,7 @@ pub fn call_method(
     object_path: &str,
     method: &str,
     param: Option<&[MessageItem]>,
+    timeout_ms: i32,
 ) -> Result<(), Box<Error>> {
     let mut m = try!(Message::new_method_call(
         SERVICE_NAME,
@@ -126,6 +128,6 @@ pub fn call_method(
         Some(p) => m.append_items(p),
         None => (),
     };
-    try!(c.send_with_reply_and_block(m, 1000));
+    try!(c.send_with_reply_and_block(m, timeout_ms));
     Ok(())
 }

--- a/src/bluetooth_utils.rs
+++ b/src/bluetooth_utils.rs
@@ -1,4 +1,4 @@
-use dbus::{Connection, BusType, Message, MessageItem, Props};
+use dbus::{Connection, Message, MessageItem, Props};
 use std::error::Error;
 
 static ADAPTER_INTERFACE: &'static str = "org.bluez.Adapter1";
@@ -8,22 +8,26 @@ static CHARACTERISTIC_INTERFACE: &'static str = "org.bluez.GattCharacteristic1";
 static DESCRIPTOR_INTERFACE: &'static str = "org.bluez.GattDescriptor1";
 static SERVICE_NAME: &'static str = "org.bluez";
 
-fn get_managed_objects(c: &Connection) ->  Result<Vec<MessageItem>, Box<Error>> {
-    let m = try!(Message::new_method_call(SERVICE_NAME, "/", "org.freedesktop.DBus.ObjectManager", "GetManagedObjects"));
+fn get_managed_objects(c: &Connection) -> Result<Vec<MessageItem>, Box<Error>> {
+    let m = try!(Message::new_method_call(
+        SERVICE_NAME,
+        "/",
+        "org.freedesktop.DBus.ObjectManager",
+        "GetManagedObjects"
+    ));
     let r = try!(c.send_with_reply_and_block(m, 1000));
     Ok(r.get_items())
 }
 
-pub fn get_adapters() -> Result<Vec<String>, Box<Error>> {
+pub fn get_adapters(c: &Connection) -> Result<Vec<String>, Box<Error>> {
     let mut adapters: Vec<String> = Vec::new();
-    let c = try!(Connection::get_private(BusType::System));
     let objects: Vec<MessageItem> = try!(get_managed_objects(&c));
     let z: &[MessageItem] = objects.get(0).unwrap().inner().unwrap();
     for y in z {
         let (path, interfaces) = y.inner().unwrap();
         let x: &[MessageItem] = interfaces.inner().unwrap();
         for interface in x {
-            let (i,_) = interface.inner().unwrap();
+            let (i, _) = interface.inner().unwrap();
             let name: &str = i.inner().unwrap();
             if name == ADAPTER_INTERFACE {
                 let p: &str = path.inner().unwrap();
@@ -34,36 +38,43 @@ pub fn get_adapters() -> Result<Vec<String>, Box<Error>> {
     Ok(adapters)
 }
 
-pub fn list_devices(adapter_path: &String) -> Result<Vec<String>, Box<Error>> {
-    list_item(DEVICE_INTERFACE, adapter_path, "Adapter")
+pub fn list_devices(c: &Connection, adapter_path: &String) -> Result<Vec<String>, Box<Error>> {
+    list_item(c, DEVICE_INTERFACE, adapter_path, "Adapter")
 }
 
-pub fn list_services(device_path: &String) -> Result<Vec<String>, Box<Error>> {
-    list_item(SERVICE_INTERFACE, device_path, "Device")
+pub fn list_services(c: &Connection, device_path: &String) -> Result<Vec<String>, Box<Error>> {
+    list_item(c, SERVICE_INTERFACE, device_path, "Device")
 }
 
-pub fn list_characteristics(device_path: &String) -> Result<Vec<String>, Box<Error>> {
-    list_item(CHARACTERISTIC_INTERFACE, device_path, "Service")
+pub fn list_characteristics(
+    c: &Connection,
+    device_path: &String,
+) -> Result<Vec<String>, Box<Error>> {
+    list_item(c, CHARACTERISTIC_INTERFACE, device_path, "Service")
 }
 
-pub fn list_descriptors(device_path: &String) -> Result<Vec<String>, Box<Error>> {
-    list_item(DESCRIPTOR_INTERFACE, device_path, "Characteristic")
+pub fn list_descriptors(c: &Connection, device_path: &String) -> Result<Vec<String>, Box<Error>> {
+    list_item(c, DESCRIPTOR_INTERFACE, device_path, "Characteristic")
 }
 
-fn list_item(item_interface: &str, item_path: &str, item_property: &str) -> Result<Vec<String>, Box<Error>> {
+fn list_item(
+    c: &Connection,
+    item_interface: &str,
+    item_path: &str,
+    item_property: &str,
+) -> Result<Vec<String>, Box<Error>> {
     let mut v: Vec<String> = Vec::new();
-    let c = try!(Connection::get_private(BusType::System));
     let objects: Vec<MessageItem> = try!(get_managed_objects(&c));
     let z: &[MessageItem] = objects.get(0).unwrap().inner().unwrap();
     for y in z {
         let (path, interfaces) = y.inner().unwrap();
         let x: &[MessageItem] = interfaces.inner().unwrap();
         for interface in x {
-            let (i,_) = interface.inner().unwrap();
+            let (i, _) = interface.inner().unwrap();
             let name: &str = i.inner().unwrap();
             if name == item_interface {
                 let objpath: &str = path.inner().unwrap();
-                let prop = try!(get_property(item_interface, objpath, item_property));
+                let prop = try!(get_property(c, item_interface, objpath, item_property));
                 let prop_path = prop.inner::<&str>().unwrap();
                 if prop_path == item_path {
                     v.push(String::from(objpath));
@@ -74,22 +85,43 @@ fn list_item(item_interface: &str, item_path: &str, item_property: &str) -> Resu
     Ok(v)
 }
 
-pub fn get_property(interface: &str, object_path: &str, prop: &str) -> Result<MessageItem, Box<Error>> {
-    let c = try!(Connection::get_private(BusType::System));
+pub fn get_property(
+    c: &Connection,
+    interface: &str,
+    object_path: &str,
+    prop: &str,
+) -> Result<MessageItem, Box<Error>> {
     let p = Props::new(&c, SERVICE_NAME, object_path, interface, 1000);
     Ok(try!(p.get(prop)).clone())
 }
 
-pub fn set_property<T>(interface: &str, object_path: &str, prop: &str, value: T) -> Result<(), Box<Error>>
-where T: Into<MessageItem> {
-    let c = try!(Connection::get_private(BusType::System));
+pub fn set_property<T>(
+    c: &Connection,
+    interface: &str,
+    object_path: &str,
+    prop: &str,
+    value: T,
+) -> Result<(), Box<Error>>
+where
+    T: Into<MessageItem>,
+{
     let p = Props::new(&c, SERVICE_NAME, object_path, interface, 1000);
     Ok(try!(p.set(prop, value.into())))
 }
 
-pub fn call_method(interface: &str, object_path: &str, method: &str, param: Option<&[MessageItem]>) -> Result<(), Box<Error>> {
-    let c = try!(Connection::get_private(BusType::System));
-    let mut m = try!(Message::new_method_call(SERVICE_NAME, object_path, interface, method));
+pub fn call_method(
+    c: &Connection,
+    interface: &str,
+    object_path: &str,
+    method: &str,
+    param: Option<&[MessageItem]>,
+) -> Result<(), Box<Error>> {
+    let mut m = try!(Message::new_method_call(
+        SERVICE_NAME,
+        object_path,
+        interface,
+        method
+    ));
     match param {
         Some(p) => m.append_items(p),
         None => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate dbus;
 extern crate hex;
 
+pub use bluetooth_session::BluetoothSession;
 pub use bluetooth_adapter::BluetoothAdapter;
 pub use bluetooth_device::BluetoothDevice;
 pub use bluetooth_gatt_characteristic::BluetoothGATTCharacteristic;
@@ -9,6 +10,7 @@ pub use bluetooth_gatt_service::BluetoothGATTService;
 pub use bluetooth_discovery_session::BluetoothDiscoverySession;
 pub use bluetooth_obex::BluetoothOBEXSession;
 
+pub mod bluetooth_session;
 pub mod bluetooth_device;
 pub mod bluetooth_adapter;
 pub mod bluetooth_gatt_characteristic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,23 @@
 extern crate dbus;
 extern crate hex;
 
-pub use bluetooth_session::BluetoothSession;
 pub use bluetooth_adapter::BluetoothAdapter;
 pub use bluetooth_device::BluetoothDevice;
+pub use bluetooth_discovery_session::BluetoothDiscoverySession;
+pub use bluetooth_event::BluetoothEvent;
 pub use bluetooth_gatt_characteristic::BluetoothGATTCharacteristic;
 pub use bluetooth_gatt_descriptor::BluetoothGATTDescriptor;
 pub use bluetooth_gatt_service::BluetoothGATTService;
-pub use bluetooth_discovery_session::BluetoothDiscoverySession;
 pub use bluetooth_obex::BluetoothOBEXSession;
+pub use bluetooth_session::BluetoothSession;
 
-pub mod bluetooth_session;
-pub mod bluetooth_device;
 pub mod bluetooth_adapter;
+pub mod bluetooth_device;
+pub mod bluetooth_discovery_session;
+pub mod bluetooth_event;
 pub mod bluetooth_gatt_characteristic;
 pub mod bluetooth_gatt_descriptor;
 pub mod bluetooth_gatt_service;
-pub mod bluetooth_discovery_session;
 pub mod bluetooth_obex;
+pub mod bluetooth_session;
 mod bluetooth_utils;


### PR DESCRIPTION
this PR includes some changes and improvements that we needed for using the crate;

- BluetoothSession is used as a persistent connection to dbus, instead of opening a different connection for each method call, the session can be initialized with an optional dbus path, which is added as `add_match` to the dbus connection (useful for filtering messages that are received via `incoming()` an example usage is in `examples/test5.rs`

- the timeout for dbus method calls is passed as an argument, most commands are left with 1000 but some (like `connect()`) have it exposed all the way to make it controllable by the user.

- BluetoothEvent is an enum for BlueZ events, `BluetoothEvent::from()` can be used to parse incoming messages into BluetoothEvent. the events that we needed are currently in the enum. usage example is also in `examples/test5.rs`

- implemented some additional functionality - `BluetoothGATTCharacteristic::acquire_write()` and `BluetoothGATTCharacteristic::acquire_notify()` (inspired by code from the somewhere in the repository's issues) and `BluetoothDiscoverySession::set_discovery_filter()`