### PR TITLE
Mark all errors Sync + Send

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -6,7 +6,7 @@ use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
 use blurz::bluetooth_device::BluetoothDevice as Device;
 use blurz::bluetooth_session::BluetoothSession as Session;
 
-fn test() -> Result<(), Box<Error>> {
+fn test() -> Result<(), Box<Error + Send + Sync>> {
     let session = &Session::create_session(None).unwrap();
     let adapter: Adapter = try!(Adapter::init(session));
     let device: Device = try!(adapter.get_first_device());

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -15,7 +15,7 @@ use blurz::bluetooth_gatt_descriptor::BluetoothGATTDescriptor as Descriptor;
 use blurz::bluetooth_gatt_service::BluetoothGATTService as Service;
 use blurz::bluetooth_session::BluetoothSession as Session;
 
-fn test2() -> Result<(), Box<Error>> {
+fn test2() -> Result<(), Box<Error + Send + Sync>> {
     let bt_session = &Session::create_session(None)?;
     let adapter: Adapter = try!(Adapter::init(bt_session));
     let session = try!(DiscoverySession::create_session(

--- a/examples/test3.rs
+++ b/examples/test3.rs
@@ -9,7 +9,7 @@ use blurz::bluetooth_device::BluetoothDevice as Device;
 use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySession;
 use blurz::bluetooth_session::BluetoothSession as Session;
 
-fn test3() -> Result<(), Box<Error>> {
+fn test3() -> Result<(), Box<Error + Send + Sync>> {
     let bt_session = &Session::create_session(None)?;
     let adapter: Adapter = try!(Adapter::init(bt_session));
     try!(adapter.set_powered(true));

--- a/examples/test4.rs
+++ b/examples/test4.rs
@@ -13,7 +13,7 @@ use blurz::bluetooth_obex::{
 };
 use blurz::bluetooth_session::BluetoothSession as Session;
 
-fn test_obex_file_transfer() -> Result<(), Box<Error>> {
+fn test_obex_file_transfer() -> Result<(), Box<Error + Send + Sync>> {
     let session = &Session::create_session(None)?;
     let adapter: Adapter = Adapter::init(session)?;
     let devices: Vec<String> = adapter.get_device_list()?;

--- a/examples/test5.rs
+++ b/examples/test5.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use blurz::bluetooth_event::BluetoothEvent;
 use blurz::bluetooth_session::BluetoothSession as Session;
 
-fn test5() -> Result<(), Box<Error>> {
+fn test5() -> Result<(), Box<Error + Send + Sync>> {
     let session = &Session::create_session(Some("/org/bluez/hci0")).unwrap();
     loop {
         for event in session.incoming(1000).map(BluetoothEvent::from) {

--- a/src/bluetooth_adapter.rs
+++ b/src/bluetooth_adapter.rs
@@ -21,7 +21,7 @@ impl<'a> BluetoothAdapter<'a> {
         }
     }
 
-    pub fn init(session: &BluetoothSession) -> Result<BluetoothAdapter, Box<Error>> {
+    pub fn init(session: &BluetoothSession) -> Result<BluetoothAdapter, Box<Error + Send + Sync>> {
         let adapters = try!(bluetooth_utils::get_adapters(session.get_connection()));
 
         if adapters.is_empty() {
@@ -34,7 +34,7 @@ impl<'a> BluetoothAdapter<'a> {
     pub fn create_adapter(
         session: &BluetoothSession,
         object_path: String,
-    ) -> Result<BluetoothAdapter, Box<Error>> {
+    ) -> Result<BluetoothAdapter, Box<Error + Send + Sync>> {
         let adapters = try!(bluetooth_utils::get_adapters(session.get_connection()));
 
         for adapter in adapters {
@@ -49,7 +49,7 @@ impl<'a> BluetoothAdapter<'a> {
         self.object_path.clone()
     }
 
-    pub fn get_first_device(&self) -> Result<BluetoothDevice, Box<Error>> {
+    pub fn get_first_device(&self) -> Result<BluetoothDevice, Box<Error + Send + Sync>> {
         let devices = try!(bluetooth_utils::list_devices(
             self.session.get_connection(),
             &self.object_path
@@ -61,11 +61,11 @@ impl<'a> BluetoothAdapter<'a> {
         Ok(BluetoothDevice::new(self.session, devices[0].clone()))
     }
 
-    pub fn get_device_list(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_device_list(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         bluetooth_utils::list_devices(self.session.get_connection(), &self.object_path)
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error + Send + Sync>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             ADAPTER_INTERFACE,
@@ -74,7 +74,7 @@ impl<'a> BluetoothAdapter<'a> {
         )
     }
 
-    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<Error>>
+    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<Error + Send + Sync>>
     where
         T: Into<MessageItem>,
     {
@@ -93,7 +93,7 @@ impl<'a> BluetoothAdapter<'a> {
         method: &str,
         param: Option<&[MessageItem]>,
         timeout_ms: i32,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             ADAPTER_INTERFACE,
@@ -109,97 +109,97 @@ impl<'a> BluetoothAdapter<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n108
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<Error + Send + Sync>> {
         let address = try!(self.get_property("Address"));
         Ok(String::from(address.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n112
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<Error + Send + Sync>> {
         let name = try!(self.get_property("Name"));
         Ok(String::from(name.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n120
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<Error + Send + Sync>> {
         let alias = try!(self.get_property("Alias"));
         Ok(String::from(alias.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n120
-    pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, value: String) -> Result<(), Box<Error + Send + Sync>> {
         self.set_property("Alias", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n139
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let class = try!(self.get_property("Class"));
         Ok(class.inner::<u32>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n147
-    pub fn is_powered(&self) -> Result<bool, Box<Error>> {
+    pub fn is_powered(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let powered = try!(self.get_property("Powered"));
         Ok(powered.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n147
-    pub fn set_powered(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_powered(&self, value: bool) -> Result<(), Box<Error + Send + Sync>> {
         self.set_property("Powered", value, 10000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n156
-    pub fn is_discoverable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_discoverable(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let discoverable = try!(self.get_property("Discoverable"));
         Ok(discoverable.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n156
-    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<Error + Send + Sync>> {
         self.set_property("Discoverable", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n176
-    pub fn is_pairable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_pairable(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let pairable = try!(self.get_property("Pairable"));
         Ok(pairable.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n176
-    pub fn set_pairable(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_pairable(&self, value: bool) -> Result<(), Box<Error + Send + Sync>> {
         self.set_property("Pairable", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n187
-    pub fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
+    pub fn get_pairable_timeout(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let pairable_timeout = try!(self.get_property("PairableTimeout"));
         Ok(pairable_timeout.inner::<u32>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n187
-    pub fn set_pairable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
+    pub fn set_pairable_timeout(&self, value: u32) -> Result<(), Box<Error + Send + Sync>> {
         self.set_property("PairableTimeout", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n196
-    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
+    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let discoverable_timeout = try!(self.get_property("DiscoverableTimeout"));
         Ok(discoverable_timeout.inner::<u32>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n196
-    pub fn set_discoverable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
+    pub fn set_discoverable_timeout(&self, value: u32) -> Result<(), Box<Error + Send + Sync>> {
         self.set_property("DiscoverableTimeout", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n205
-    pub fn is_discovering(&self) -> Result<bool, Box<Error>> {
+    pub fn is_discovering(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let discovering = try!(self.get_property("Discovering"));
         Ok(discovering.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n209
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         let uuids = try!(self.get_property("UUIDs"));
         let z: &[MessageItem] = uuids.inner().unwrap();
         let mut v: Vec<String> = Vec::new();
@@ -210,7 +210,7 @@ impl<'a> BluetoothAdapter<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n215
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error + Send + Sync>> {
         let modalias = try!(self.get_property("Modalias"));
         let m = modalias.inner::<&str>().unwrap();
         let ids: Vec<&str> = m.split(":").collect();
@@ -228,22 +228,22 @@ impl<'a> BluetoothAdapter<'a> {
         ))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error + Send + Sync>> {
         let (vendor_id_source, _, _, _) = try!(self.get_modalias());
         Ok(vendor_id_source)
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let (_, vendor_id, _, _) = try!(self.get_modalias());
         Ok(vendor_id)
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let (_, _, product_id, _) = try!(self.get_modalias());
         Ok(product_id)
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let (_, _, _, device_id) = try!(self.get_modalias());
         Ok(device_id)
     }
@@ -253,17 +253,17 @@ impl<'a> BluetoothAdapter<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n12
-    pub fn start_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn start_discovery(&self) -> Result<(), Box<Error + Send + Sync>> {
         Err(Box::from("Deprecated, use Discovery Session"))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n27
-    pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn stop_discovery(&self) -> Result<(), Box<Error + Send + Sync>> {
         Err(Box::from("Deprecated, use Discovery Session"))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n40
-    pub fn remove_device(&self, device: String) -> Result<(), Box<Error>> {
+    pub fn remove_device(&self, device: String) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method(
             "RemoveDevice",
             Some(&[MessageItem::ObjectPath(device.into())]),

--- a/src/bluetooth_device.rs
+++ b/src/bluetooth_device.rs
@@ -25,7 +25,7 @@ impl<'a> BluetoothDevice<'a> {
         self.object_path.clone()
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error + Send + Sync>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             DEVICE_INTERFACE,
@@ -34,7 +34,7 @@ impl<'a> BluetoothDevice<'a> {
         )
     }
 
-    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<Error>>
+    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<Error + Send + Sync>>
     where
         T: Into<MessageItem>,
     {
@@ -53,7 +53,7 @@ impl<'a> BluetoothDevice<'a> {
         method: &str,
         param: Option<&[MessageItem]>,
         timeout_ms: i32,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             DEVICE_INTERFACE,
@@ -68,37 +68,37 @@ impl<'a> BluetoothDevice<'a> {
      * Properties
      */
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n105
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<Error + Send + Sync>> {
         let address = try!(self.get_property("Address"));
         Ok(String::from(address.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n109
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<Error + Send + Sync>> {
         let name = try!(self.get_property("Name"));
         Ok(String::from(name.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n121
-    pub fn get_icon(&self) -> Result<String, Box<Error>> {
+    pub fn get_icon(&self) -> Result<String, Box<Error + Send + Sync>> {
         let icon = try!(self.get_property("Icon"));
         Ok(String::from(icon.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n126
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let class = try!(self.get_property("Class"));
         Ok(class.inner::<u32>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n126
-    pub fn get_appearance(&self) -> Result<u16, Box<Error>> {
+    pub fn get_appearance(&self) -> Result<u16, Box<Error + Send + Sync>> {
         let appearance = try!(self.get_property("Appearance"));
         Ok(appearance.inner::<u16>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n134
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         let uuids = try!(self.get_property("UUIDs"));
         let z: &[MessageItem] = uuids.inner().unwrap();
         let mut v: Vec<String> = Vec::new();
@@ -109,13 +109,13 @@ impl<'a> BluetoothDevice<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n139
-    pub fn is_paired(&self) -> Result<bool, Box<Error>> {
+    pub fn is_paired(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let paired = try!(self.get_property("Paired"));
         Ok(paired.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n143
-    pub fn is_connected(&self) -> Result<bool, Box<Error>> {
+    pub fn is_connected(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let connected = try!(self.get_property("Connected"));
         Ok(connected.inner::<bool>().unwrap())
     }
@@ -133,47 +133,47 @@ impl<'a> BluetoothDevice<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n149
-    pub fn set_trusted(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_trusted(&self, value: bool) -> Result<(), Box<Error + Send + Sync>> {
         self.set_property("Trusted", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n149
-    pub fn is_trusted(&self) -> Result<bool, Box<Error>> {
+    pub fn is_trusted(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let trusted = try!(self.get_property("Trusted"));
         Ok(trusted.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n154
-    pub fn is_blocked(&self) -> Result<bool, Box<Error>> {
+    pub fn is_blocked(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let blocked = try!(self.get_property("Blocked"));
         Ok(blocked.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n161
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<Error + Send + Sync>> {
         let alias = try!(self.get_property("Alias"));
         Ok(String::from(alias.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n161
-    pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, value: String) -> Result<(), Box<Error + Send + Sync>> {
         self.set_property("Alias", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n174
-    pub fn get_adapter(&self) -> Result<String, Box<Error>> {
+    pub fn get_adapter(&self) -> Result<String, Box<Error + Send + Sync>> {
         let adapter = try!(self.get_property("Adapter"));
         Ok(String::from(adapter.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n178
-    pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
+    pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let legacy_pairing = try!(self.get_property("LegacyPairing"));
         Ok(legacy_pairing.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n189
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error + Send + Sync>> {
         let modalias = try!(self.get_property("Modalias"));
         let m = modalias.inner::<&str>().unwrap();
         let ids: Vec<&str> = m.split(":").collect();
@@ -191,40 +191,40 @@ impl<'a> BluetoothDevice<'a> {
         ))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error + Send + Sync>> {
         let (vendor_id_source, _, _, _) = try!(self.get_modalias());
         Ok(vendor_id_source)
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let (_, vendor_id, _, _) = try!(self.get_modalias());
         Ok(vendor_id)
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let (_, _, product_id, _) = try!(self.get_modalias());
         Ok(product_id)
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<Error + Send + Sync>> {
         let (_, _, _, device_id) = try!(self.get_modalias());
         Ok(device_id)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n194
-    pub fn get_rssi(&self) -> Result<i16, Box<Error>> {
+    pub fn get_rssi(&self) -> Result<i16, Box<Error + Send + Sync>> {
         let rssi = try!(self.get_property("RSSI"));
         Ok(rssi.inner::<i16>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n199
-    pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
+    pub fn get_tx_power(&self) -> Result<i16, Box<Error + Send + Sync>> {
         let tx_power = try!(self.get_property("TxPower"));
         Ok(tx_power.inner::<i16>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n204
-    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<Error>> {
+    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<Error + Send + Sync>> {
         let manufacturer_data_array = try!(self.get_property("ManufacturerData"));
         let mut m = HashMap::new();
         let dict_vec = manufacturer_data_array
@@ -246,7 +246,7 @@ impl<'a> BluetoothDevice<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n210
-    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<Error>> {
+    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<Error + Send + Sync>> {
         let service_data_array = try!(self.get_property("ServiceData"));
         let mut m = HashMap::new();
         let dict_vec = service_data_array.inner::<&Vec<MessageItem>>().unwrap();
@@ -266,7 +266,7 @@ impl<'a> BluetoothDevice<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n215
-    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         bluetooth_utils::list_services(self.session.get_connection(), &self.object_path)
     }
 
@@ -275,32 +275,32 @@ impl<'a> BluetoothDevice<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n12
-    pub fn connect(&self, timeout_ms: i32) -> Result<(), Box<Error>> {
+    pub fn connect(&self, timeout_ms: i32) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("Connect", None, timeout_ms)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n29
-    pub fn disconnect(&self) -> Result<(), Box<Error>> {
+    pub fn disconnect(&self) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("Disconnect", None, 5000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n43
-    pub fn connect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn connect_profile(&self, uuid: String) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("ConnectProfile", Some(&[uuid.into()]), 30000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n55
-    pub fn disconnect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn disconnect_profile(&self, uuid: String) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("DisconnectProfile", Some(&[uuid.into()]), 5000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n70
-    pub fn pair(&self) -> Result<(), Box<Error>> {
+    pub fn pair(&self) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("Pair", None, 60000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n97
-    pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
+    pub fn cancel_pairing(&self) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("CancelPairing", None, 5000)
     }
 }

--- a/src/bluetooth_discovery_session.rs
+++ b/src/bluetooth_discovery_session.rs
@@ -14,7 +14,7 @@ impl<'a> BluetoothDiscoverySession<'a> {
     pub fn create_session(
         session: &'a BluetoothSession,
         adapter: String,
-    ) -> Result<BluetoothDiscoverySession, Box<Error>> {
+    ) -> Result<BluetoothDiscoverySession, Box<Error + Send + Sync>> {
         Ok(BluetoothDiscoverySession::new(session, adapter))
     }
 
@@ -25,7 +25,7 @@ impl<'a> BluetoothDiscoverySession<'a> {
         }
     }
 
-    fn call_method(&self, method: &str, param: Option<[MessageItem; 1]>) -> Result<(), Box<Error>> {
+    fn call_method(&self, method: &str, param: Option<[MessageItem; 1]>) -> Result<(), Box<Error + Send + Sync>> {
         let mut m = try!(Message::new_method_call(
             SERVICE_NAME,
             &self.adapter,
@@ -44,11 +44,11 @@ impl<'a> BluetoothDiscoverySession<'a> {
         Ok(())
     }
 
-    pub fn start_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn start_discovery(&self) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("StartDiscovery", None)
     }
 
-    pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn stop_discovery(&self) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("StopDiscovery", None)
     }
 
@@ -57,7 +57,7 @@ impl<'a> BluetoothDiscoverySession<'a> {
         uuids: Vec<String>,
         rssi: Option<i16>,
         pathloss: Option<u16>,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         let uuids = {
             let mut res: Vec<MessageItem> = Vec::new();
             for u in uuids {

--- a/src/bluetooth_gatt_characteristic.rs
+++ b/src/bluetooth_gatt_characteristic.rs
@@ -25,7 +25,7 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
         self.object_path.clone()
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error + Send + Sync>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             GATT_CHARACTERISTIC_INTERFACE,
@@ -39,7 +39,7 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
         method: &str,
         param: Option<&[MessageItem]>,
         timeout_ms: i32,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             GATT_CHARACTERISTIC_INTERFACE,
@@ -55,19 +55,19 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n114
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<Error + Send + Sync>> {
         let uuid = try!(self.get_property("UUID"));
         Ok(String::from(uuid.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n118
-    pub fn get_service(&self) -> Result<String, Box<Error>> {
+    pub fn get_service(&self) -> Result<String, Box<Error + Send + Sync>> {
         let service = try!(self.get_property("Service"));
         Ok(String::from(service.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n123
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error + Send + Sync>> {
         let value = try!(self.get_property("Value"));
         let z: &[MessageItem] = value.inner().unwrap();
         let mut v: Vec<u8> = Vec::new();
@@ -78,13 +78,13 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n130
-    pub fn is_notifying(&self) -> Result<bool, Box<Error>> {
+    pub fn is_notifying(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let notifying = try!(self.get_property("Notifying"));
         Ok(notifying.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n135
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         let flags = try!(self.get_property("Flags"));
         let z: &[MessageItem] = flags.inner().unwrap();
         let mut v: Vec<String> = Vec::new();
@@ -95,7 +95,7 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n156
-    pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         bluetooth_utils::list_descriptors(self.session.get_connection(), &self.object_path)
     }
 
@@ -104,7 +104,7 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n72
-    pub fn read_value(&self, offset: Option<u16>) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self, offset: Option<u16>) -> Result<Vec<u8>, Box<Error + Send + Sync>> {
         let c = try!(Connection::get_private(BusType::System));
         let mut m = try!(Message::new_method_call(
             SERVICE_NAME,
@@ -135,7 +135,7 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n84
-    pub fn write_value(&self, values: Vec<u8>, offset: Option<u16>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, values: Vec<u8>, offset: Option<u16>) -> Result<(), Box<Error + Send + Sync>> {
         let values_msgs = {
             let mut res: Vec<MessageItem> = Vec::new();
             for v in values {
@@ -165,16 +165,16 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n96
-    pub fn start_notify(&self) -> Result<(), Box<Error>> {
+    pub fn start_notify(&self) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("StartNotify", None, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n105
-    pub fn stop_notify(&self) -> Result<(), Box<Error>> {
+    pub fn stop_notify(&self) -> Result<(), Box<Error + Send + Sync>> {
         self.call_method("StopNotify", None, 1000)
     }
 
-    pub fn acquire_notify(&self) -> Result<(OwnedFd, u16), Box<Error>> {
+    pub fn acquire_notify(&self) -> Result<(OwnedFd, u16), Box<Error + Send + Sync>> {
         let mut m = Message::new_method_call(
             SERVICE_NAME,
             &self.object_path,
@@ -192,7 +192,7 @@ impl<'a> BluetoothGATTCharacteristic<'a> {
         Ok((opt_fd.unwrap(), opt_mtu.unwrap()))
     }
 
-    pub fn acquire_write(&self) -> Result<(OwnedFd, u16), Box<Error>> {
+    pub fn acquire_write(&self) -> Result<(OwnedFd, u16), Box<Error + Send + Sync>> {
         let mut m = Message::new_method_call(
             SERVICE_NAME,
             &self.object_path,

--- a/src/bluetooth_gatt_descriptor.rs
+++ b/src/bluetooth_gatt_descriptor.rs
@@ -25,7 +25,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
         self.object_path.clone()
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error + Send + Sync>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             GATT_DESCRIPTOR_INTERFACE,
@@ -39,7 +39,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
         method: &str,
         param: Option<&[MessageItem]>,
         timeout_ms: i32,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             GATT_DESCRIPTOR_INTERFACE,
@@ -55,19 +55,19 @@ impl<'a> BluetoothGATTDescriptor<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n198
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<Error + Send + Sync>> {
         let uuid = try!(self.get_property("UUID"));
         Ok(String::from(uuid.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n202
-    pub fn get_characteristic(&self) -> Result<String, Box<Error>> {
+    pub fn get_characteristic(&self) -> Result<String, Box<Error + Send + Sync>> {
         let service = try!(self.get_property("Characteristic"));
         Ok(String::from(service.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n207
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error + Send + Sync>> {
         let value = try!(self.get_property("Value"));
         let z: &[MessageItem] = value.inner().unwrap();
         let mut v: Vec<u8> = Vec::new();
@@ -78,7 +78,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n213
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         let flags = try!(self.get_property("Flags"));
         let z: &[MessageItem] = flags.inner().unwrap();
         let mut v: Vec<String> = Vec::new();
@@ -93,7 +93,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n174
-    pub fn read_value(&self, offset: Option<u16>) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self, offset: Option<u16>) -> Result<Vec<u8>, Box<Error + Send + Sync>> {
         let c = try!(Connection::get_private(BusType::System));
         let mut m = try!(Message::new_method_call(
             SERVICE_NAME,
@@ -124,7 +124,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n186
-    pub fn write_value(&self, values: Vec<u8>, offset: Option<u16>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, values: Vec<u8>, offset: Option<u16>) -> Result<(), Box<Error + Send + Sync>> {
         let args = {
             let mut res: Vec<MessageItem> = Vec::new();
             for v in values {

--- a/src/bluetooth_gatt_service.rs
+++ b/src/bluetooth_gatt_service.rs
@@ -24,7 +24,7 @@ impl<'a> BluetoothGATTService<'a> {
         self.object_path.clone()
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error + Send + Sync>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             GATT_SERVICE_INTERFACE,
@@ -38,29 +38,29 @@ impl<'a> BluetoothGATTService<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n33
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<Error + Send + Sync>> {
         let uuid = try!(self.get_property("UUID"));
         Ok(String::from(uuid.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n37
-    pub fn is_primary(&self) -> Result<bool, Box<Error>> {
+    pub fn is_primary(&self) -> Result<bool, Box<Error + Send + Sync>> {
         let primary = try!(self.get_property("Primary"));
         Ok(primary.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n42
-    pub fn get_device(&self) -> Result<String, Box<Error>> {
+    pub fn get_device(&self) -> Result<String, Box<Error + Send + Sync>> {
         let device = try!(self.get_property("Device"));
         Ok(String::from(device.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n48
-    pub fn get_includes(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_includes(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         Err(Box::from("Not implemented"))
     }
 
-    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<Error + Send + Sync>> {
         bluetooth_utils::list_characteristics(self.session.get_connection(), &self.object_path)
     }
 }

--- a/src/bluetooth_obex.rs
+++ b/src/bluetooth_obex.rs
@@ -57,7 +57,7 @@ impl TransferState {
     }
 }
 
-pub fn open_bus_connection() -> Result<Connection, Box<Error>> {
+pub fn open_bus_connection() -> Result<Connection, Box<Error + Send + Sync>> {
     let c = Connection::get_private(BusType::Session)?;
     Ok(c)
 }
@@ -72,7 +72,7 @@ impl<'a> BluetoothOBEXSession<'a> {
     pub fn new(
         session: &'a BluetoothSession,
         device: &BluetoothDevice,
-    ) -> Result<BluetoothOBEXSession<'a>, Box<Error>> {
+    ) -> Result<BluetoothOBEXSession<'a>, Box<Error + Send + Sync>> {
         let device_address: String = device.get_address()?;
         let mut map = HashMap::new();
         map.insert("Target", Variant(SessionTarget::Opp.as_str()));
@@ -93,7 +93,7 @@ impl<'a> BluetoothOBEXSession<'a> {
     }
 
     // https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/obex-api.txt#n35
-    pub fn remove_session(&self) -> Result<(), Box<Error>> {
+    pub fn remove_session(&self) -> Result<(), Box<Error + Send + Sync>> {
         let object_path = ObjectPath::new(self.object_path.as_bytes())?;
         let m = Message::new_method_call(OBEX_BUS, OBEX_PATH, CLIENT_INTERFACE, "RemoveSession")?
             .append1(object_path);
@@ -116,7 +116,7 @@ impl<'a> BluetoothOBEXTransfer<'a> {
     pub fn send_file(
         session: &'a BluetoothOBEXSession,
         file_path: &str,
-    ) -> Result<BluetoothOBEXTransfer<'a>, Box<Error>> {
+    ) -> Result<BluetoothOBEXTransfer<'a>, Box<Error + Send + Sync>> {
         let session_path: String = session.object_path.clone();
         let m =
             Message::new_method_call(OBEX_BUS, session_path, OBJECT_PUSH_INTERFACE, "SendFile")?
@@ -142,7 +142,7 @@ impl<'a> BluetoothOBEXTransfer<'a> {
     }
 
     // https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/obex-api.txt#n115
-    pub fn status(&self) -> Result<String, Box<Error>> {
+    pub fn status(&self) -> Result<String, Box<Error + Send + Sync>> {
         let transfer_path = self.object_path.clone();
         let p = Props::new(
             &self.session.session.get_connection(),
@@ -158,7 +158,7 @@ impl<'a> BluetoothOBEXTransfer<'a> {
         }
     }
 
-    pub fn wait_until_transfer_completed(&self) -> Result<(), Box<Error>> {
+    pub fn wait_until_transfer_completed(&self) -> Result<(), Box<Error + Send + Sync>> {
         sleep(Duration::from_millis(500));
         let mut transfer_status: String = self.status()?;
 

--- a/src/bluetooth_session.rs
+++ b/src/bluetooth_session.rs
@@ -10,7 +10,7 @@ pub struct BluetoothSession {
 }
 
 impl BluetoothSession {
-    pub fn create_session(path: Option<&str>) -> Result<BluetoothSession, Box<Error>> {
+    pub fn create_session(path: Option<&str>) -> Result<BluetoothSession, Box<Error + Send + Sync>> {
         let rule = {
             if let Some(path) = path {
                 format!("{},path='{}'", BLUEZ_MATCH, path)

--- a/src/bluetooth_utils.rs
+++ b/src/bluetooth_utils.rs
@@ -8,7 +8,7 @@ static CHARACTERISTIC_INTERFACE: &'static str = "org.bluez.GattCharacteristic1";
 static DESCRIPTOR_INTERFACE: &'static str = "org.bluez.GattDescriptor1";
 static SERVICE_NAME: &'static str = "org.bluez";
 
-fn get_managed_objects(c: &Connection) -> Result<Vec<MessageItem>, Box<Error>> {
+fn get_managed_objects(c: &Connection) -> Result<Vec<MessageItem>, Box<Error + Send + Sync>> {
     let m = try!(Message::new_method_call(
         SERVICE_NAME,
         "/",
@@ -19,7 +19,7 @@ fn get_managed_objects(c: &Connection) -> Result<Vec<MessageItem>, Box<Error>> {
     Ok(r.get_items())
 }
 
-pub fn get_adapters(c: &Connection) -> Result<Vec<String>, Box<Error>> {
+pub fn get_adapters(c: &Connection) -> Result<Vec<String>, Box<Error + Send + Sync>> {
     let mut adapters: Vec<String> = Vec::new();
     let objects: Vec<MessageItem> = try!(get_managed_objects(&c));
     let z: &[MessageItem] = objects.get(0).unwrap().inner().unwrap();
@@ -38,22 +38,22 @@ pub fn get_adapters(c: &Connection) -> Result<Vec<String>, Box<Error>> {
     Ok(adapters)
 }
 
-pub fn list_devices(c: &Connection, adapter_path: &String) -> Result<Vec<String>, Box<Error>> {
+pub fn list_devices(c: &Connection, adapter_path: &String) -> Result<Vec<String>, Box<Error + Send + Sync>> {
     list_item(c, DEVICE_INTERFACE, adapter_path, "Adapter")
 }
 
-pub fn list_services(c: &Connection, device_path: &String) -> Result<Vec<String>, Box<Error>> {
+pub fn list_services(c: &Connection, device_path: &String) -> Result<Vec<String>, Box<Error + Send + Sync>> {
     list_item(c, SERVICE_INTERFACE, device_path, "Device")
 }
 
 pub fn list_characteristics(
     c: &Connection,
     device_path: &String,
-) -> Result<Vec<String>, Box<Error>> {
+) -> Result<Vec<String>, Box<Error + Send + Sync>> {
     list_item(c, CHARACTERISTIC_INTERFACE, device_path, "Service")
 }
 
-pub fn list_descriptors(c: &Connection, device_path: &String) -> Result<Vec<String>, Box<Error>> {
+pub fn list_descriptors(c: &Connection, device_path: &String) -> Result<Vec<String>, Box<Error + Send + Sync>> {
     list_item(c, DESCRIPTOR_INTERFACE, device_path, "Characteristic")
 }
 
@@ -62,7 +62,7 @@ fn list_item(
     item_interface: &str,
     item_path: &str,
     item_property: &str,
-) -> Result<Vec<String>, Box<Error>> {
+) -> Result<Vec<String>, Box<Error + Send + Sync>> {
     let mut v: Vec<String> = Vec::new();
     let objects: Vec<MessageItem> = try!(get_managed_objects(&c));
     let z: &[MessageItem] = objects.get(0).unwrap().inner().unwrap();
@@ -90,7 +90,7 @@ pub fn get_property(
     interface: &str,
     object_path: &str,
     prop: &str,
-) -> Result<MessageItem, Box<Error>> {
+) -> Result<MessageItem, Box<Error + Send + Sync>> {
     let p = Props::new(&c, SERVICE_NAME, object_path, interface, 1000);
     Ok(try!(p.get(prop)).clone())
 }
@@ -102,7 +102,7 @@ pub fn set_property<T>(
     prop: &str,
     value: T,
     timeout_ms: i32,
-) -> Result<(), Box<Error>>
+) -> Result<(), Box<Error + Send + Sync>>
 where
     T: Into<MessageItem>,
 {
@@ -117,7 +117,7 @@ pub fn call_method(
     method: &str,
     param: Option<&[MessageItem]>,
     timeout_ms: i32,
-) -> Result<(), Box<Error>> {
+) -> Result<(), Box<Error + Send + Sync>> {
     let mut m = try!(Message::new_method_call(
         SERVICE_NAME,
         object_path,


### PR DESCRIPTION
This is required by [`failure::from_boxed_compat`](https://docs.rs/failure/0.1.5/failure/struct.Error.html#method.from_boxed_compat). `Sync` is not strictly required (it can be wrapped in a mutex separately), but we might as well forward it if the underlying error provides it.