### PR TITLE
Add example 6 to list devices and services

### DIFF
--- a/examples/test6.rs
+++ b/examples/test6.rs
@@ -1,0 +1,105 @@
+extern crate blurz;
+
+use std::error::Error;
+use std::thread;
+use std::time::Duration;
+
+use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
+use blurz::bluetooth_device::BluetoothDevice as Device;
+use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as DiscoverySession;
+use blurz::bluetooth_session::BluetoothSession as Session;
+use blurz::BluetoothGATTService;
+use blurz::BluetoothGATTCharacteristic;
+
+
+fn test6() -> Result<(), Box<Error>> {
+    let bt_session = &Session::create_session(None)?;
+    let adapter: Adapter = Adapter::init(bt_session)?;
+    adapter.set_powered(true)?;
+
+    let session = DiscoverySession::create_session(
+        &bt_session,
+        adapter.get_id()
+    )?;
+    thread::sleep(Duration::from_millis(200));
+    session.start_discovery()?;
+    thread::sleep(Duration::from_millis(800));
+    let devices = adapter.get_device_list()?;
+
+    println!("{} device(s) found", devices.len());
+    println!();
+
+    'device_loop: for d in devices {
+        let device = Device::new(bt_session, d.clone());
+
+        println!(
+            "Device: Id: {} Address: {:?} Rssi: {:?} Name: {:?}",
+            device.get_id(),
+            device.get_address(),
+            device.get_rssi(),
+            device.get_name()
+        );
+
+        if let Err(e) = device.pair() {
+            println!("  Error on pairing: {:?}", e);
+        }
+
+        println!("  Is paired: {:?}", device.is_paired());
+
+        //device.connect(5000);
+
+        println!("  Is connected: {:?}", device.is_connected());
+
+        match device.is_ready_to_receive() {
+            Some(v) => println!("  Is ready to receive: {:?}", v),
+            None => println!("  Error is_ready_to_receive()")
+        }
+
+        let all_gatt_services = device.get_gatt_services();
+
+        match all_gatt_services {
+            Ok(gatt_services) => {
+                for service in gatt_services {
+                    let gatt_service = BluetoothGATTService::new(bt_session, service);
+
+                    println!("  Gatt service Id: {} UUID: {:?} Device : {:?} Is primary: {:?}",
+                             gatt_service.get_id(),
+                             gatt_service.get_uuid(),
+                             gatt_service.get_device(),
+                             gatt_service.is_primary());
+
+                    match gatt_service.get_gatt_characteristics() {
+                        Ok(ref gat_chars) => {
+                            for characteristics in gat_chars {
+                                let gatt_char = BluetoothGATTCharacteristic::new(bt_session, characteristics.to_owned());
+
+                                println!("    Characteristic Name: {} UUID: {:?} Flags: {:?}",
+                                         characteristics, gatt_char.get_uuid(),
+                                         gatt_char.get_flags());
+                            }
+                        },
+                        Err(e) => println!("    Error get_gatt_characteristics(): {:?}", e)
+                    }
+                }
+            },
+            Err(e) => println!("{:?}", e)
+        }
+
+        if let Err(e) = device.disconnect() {
+            println!("  Error on disconnect: {:?}", e);
+        }
+
+        adapter.remove_device(device.get_id())?;
+    }
+    session.stop_discovery()?;
+
+    Ok(())
+
+}
+
+fn main() {
+    match test6() {
+        Ok(_) => (),
+        Err(e) => println!("{:?}", e),
+    }
+}


### PR DESCRIPTION
Add a example with list devices, services...
```
1 device(s) found

Device: Id: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx Address: Ok("xx:xx:xx:xx:xx:xx") Rssi: Ok(-39) Name: Ok("xxx-xxxx")
  Is paired: Ok(true)
  Is connected: Ok(true)
  Is ready to receive: true
  Gatt service Id: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service001a UUID: Ok("00010001-574f-4f20-5370-6865726f2121") Device : Ok("/org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx") Is primary: Ok(true)
    Characteristic Name: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service001a/char001e UUID: Ok("00010003-574f-4f20-5370-6865726f2121") Flags: Ok(["write-without-response", "write", "notify"])
    Characteristic Name: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service001a/char001b UUID: Ok("00010002-574f-4f20-5370-6865726f2121") Flags: Ok(["write-without-response", "write", "notify"])
  Gatt service Id: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service000c UUID: Ok("00020001-574f-4f20-5370-6865726f2121") Device : Ok("/org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx") Is primary: Ok(true)
    Characteristic Name: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service000c/char0014 UUID: Ok("00020005-574f-4f20-5370-6865726f2121") Flags: Ok(["write-without-response", "write"])
    Characteristic Name: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service000c/char0012 UUID: Ok("00020004-574f-4f20-5370-6865726f2121") Flags: Ok(["read"])
    Characteristic Name: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service000c/char000f UUID: Ok("00020002-574f-4f20-5370-6865726f2121") Flags: Ok(["write", "notify"])
    Characteristic Name: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service000c/char000d UUID: Ok("00020003-574f-4f20-5370-6865726f2121") Flags: Ok(["write-without-response"])
  Gatt service Id: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service0008 UUID: Ok("00001801-0000-1000-8000-00805f9b34fb") Device : Ok("/org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx") Is primary: Ok(true)
    Characteristic Name: /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/service0008/char0009 UUID: Ok("00002a05-0000-1000-8000-00805f9b34fb") Flags: Ok(["indicate"])
```