### PR TITLE
Migrate to Rust edition 2018 + fix some clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Attila Dusnoki <adusnoki@inf.u-szeged.hu>"]
 repository = "https://github.com/szeged/blurz"
 keywords = ["bluetooth", "bluez", "ble"]
 license = "BSD-2-Clause"
+edition = "2018"
 
 [lib]
 name = "blurz"

--- a/src/bluetooth_adapter.rs
+++ b/src/bluetooth_adapter.rs
@@ -1,11 +1,11 @@
-use bluetooth_device::BluetoothDevice;
-use bluetooth_session::BluetoothSession;
-use bluetooth_utils;
+use crate::bluetooth_device::BluetoothDevice;
+use crate::bluetooth_session::BluetoothSession;
+use crate::bluetooth_utils;
 use dbus::MessageItem;
 use hex::FromHex;
 use std::error::Error;
 
-static ADAPTER_INTERFACE: &'static str = "org.bluez.Adapter1";
+static ADAPTER_INTERFACE: &str = "org.bluez.Adapter1";
 
 #[derive(Clone)]
 pub struct BluetoothAdapter<'a> {
@@ -16,13 +16,13 @@ pub struct BluetoothAdapter<'a> {
 impl<'a> BluetoothAdapter<'a> {
     fn new(session: &'a BluetoothSession, object_path: String) -> BluetoothAdapter<'a> {
         BluetoothAdapter {
-            object_path: object_path,
-            session: session,
+            object_path,
+            session,
         }
     }
 
-    pub fn init(session: &BluetoothSession) -> Result<BluetoothAdapter, Box<Error>> {
-        let adapters = try!(bluetooth_utils::get_adapters(session.get_connection()));
+    pub fn init(session: &BluetoothSession) -> Result<BluetoothAdapter, Box<dyn Error>> {
+        let adapters = bluetooth_utils::get_adapters(session.get_connection())?;
 
         if adapters.is_empty() {
             return Err(Box::from("Bluetooth adapter not found"));
@@ -34,8 +34,8 @@ impl<'a> BluetoothAdapter<'a> {
     pub fn create_adapter(
         session: &BluetoothSession,
         object_path: String,
-    ) -> Result<BluetoothAdapter, Box<Error>> {
-        let adapters = try!(bluetooth_utils::get_adapters(session.get_connection()));
+    ) -> Result<BluetoothAdapter, Box<dyn Error>> {
+        let adapters = bluetooth_utils::get_adapters(session.get_connection())?;
 
         for adapter in adapters {
             if adapter == object_path {
@@ -49,11 +49,11 @@ impl<'a> BluetoothAdapter<'a> {
         self.object_path.clone()
     }
 
-    pub fn get_first_device(&self) -> Result<BluetoothDevice, Box<Error>> {
-        let devices = try!(bluetooth_utils::list_devices(
+    pub fn get_first_device(&self) -> Result<BluetoothDevice, Box<dyn Error>> {
+        let devices =bluetooth_utils::list_devices(
             self.session.get_connection(),
             &self.object_path
-        ));
+        )?;
 
         if devices.is_empty() {
             return Err(Box::from("No device found."));
@@ -61,11 +61,11 @@ impl<'a> BluetoothAdapter<'a> {
         Ok(BluetoothDevice::new(self.session, devices[0].clone()))
     }
 
-    pub fn get_device_list(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_device_list(&self) -> Result<Vec<String>, Box<dyn Error>> {
         bluetooth_utils::list_devices(self.session.get_connection(), &self.object_path)
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<dyn Error>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             ADAPTER_INTERFACE,
@@ -74,7 +74,7 @@ impl<'a> BluetoothAdapter<'a> {
         )
     }
 
-    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<Error>>
+    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<dyn Error>>
     where
         T: Into<MessageItem>,
     {
@@ -93,7 +93,7 @@ impl<'a> BluetoothAdapter<'a> {
         method: &str,
         param: Option<&[MessageItem]>,
         timeout_ms: i32,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             ADAPTER_INTERFACE,
@@ -109,98 +109,98 @@ impl<'a> BluetoothAdapter<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n108
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
-        let address = try!(self.get_property("Address"));
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
+        let address = self.get_property("Address")?;
         Ok(String::from(address.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n112
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
-        let name = try!(self.get_property("Name"));
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
+        let name = self.get_property("Name")?;
         Ok(String::from(name.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n120
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
-        let alias = try!(self.get_property("Alias"));
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
+        let alias = self.get_property("Alias")?;
         Ok(String::from(alias.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n120
-    pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, value: String) -> Result<(), Box<dyn Error>> {
         self.set_property("Alias", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n139
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
-        let class = try!(self.get_property("Class"));
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
+        let class = self.get_property("Class")?;
         Ok(class.inner::<u32>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n147
-    pub fn is_powered(&self) -> Result<bool, Box<Error>> {
-        let powered = try!(self.get_property("Powered"));
+    pub fn is_powered(&self) -> Result<bool, Box<dyn Error>> {
+        let powered = self.get_property("Powered")?;
         Ok(powered.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n147
-    pub fn set_powered(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_powered(&self, value: bool) -> Result<(), Box<dyn Error>> {
         self.set_property("Powered", value, 10000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n156
-    pub fn is_discoverable(&self) -> Result<bool, Box<Error>> {
-        let discoverable = try!(self.get_property("Discoverable"));
+    pub fn is_discoverable(&self) -> Result<bool, Box<dyn Error>> {
+        let discoverable = self.get_property("Discoverable")?;
         Ok(discoverable.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n156
-    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<dyn Error>> {
         self.set_property("Discoverable", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n176
-    pub fn is_pairable(&self) -> Result<bool, Box<Error>> {
-        let pairable = try!(self.get_property("Pairable"));
+    pub fn is_pairable(&self) -> Result<bool, Box<dyn Error>> {
+        let pairable = self.get_property("Pairable")?;
         Ok(pairable.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n176
-    pub fn set_pairable(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_pairable(&self, value: bool) -> Result<(), Box<dyn Error>> {
         self.set_property("Pairable", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n187
-    pub fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
-        let pairable_timeout = try!(self.get_property("PairableTimeout"));
+    pub fn get_pairable_timeout(&self) -> Result<u32, Box<dyn Error>> {
+        let pairable_timeout = self.get_property("PairableTimeout")?;
         Ok(pairable_timeout.inner::<u32>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n187
-    pub fn set_pairable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
+    pub fn set_pairable_timeout(&self, value: u32) -> Result<(), Box<dyn Error>> {
         self.set_property("PairableTimeout", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n196
-    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
-        let discoverable_timeout = try!(self.get_property("DiscoverableTimeout"));
+    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<dyn Error>> {
+        let discoverable_timeout = self.get_property("DiscoverableTimeout")?;
         Ok(discoverable_timeout.inner::<u32>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n196
-    pub fn set_discoverable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
+    pub fn set_discoverable_timeout(&self, value: u32) -> Result<(), Box<dyn Error>> {
         self.set_property("DiscoverableTimeout", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n205
-    pub fn is_discovering(&self) -> Result<bool, Box<Error>> {
-        let discovering = try!(self.get_property("Discovering"));
+    pub fn is_discovering(&self) -> Result<bool, Box<dyn Error>> {
+        let discovering = self.get_property("Discovering")?;
         Ok(discovering.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n209
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-        let uuids = try!(self.get_property("UUIDs"));
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
+        let uuids = self.get_property("UUIDs")?;
         let z: &[MessageItem] = uuids.inner().unwrap();
         let mut v: Vec<String> = Vec::new();
         for y in z {
@@ -210,10 +210,10 @@ impl<'a> BluetoothAdapter<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n215
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        let modalias = try!(self.get_property("Modalias"));
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
+        let modalias = self.get_property("Modalias")?;
         let m = modalias.inner::<&str>().unwrap();
-        let ids: Vec<&str> = m.split(":").collect();
+        let ids: Vec<&str> = m.split(':').collect();
 
         let source = String::from(ids[0]);
         let vendor = Vec::from_hex(ids[1][1..5].to_string()).unwrap();
@@ -228,23 +228,23 @@ impl<'a> BluetoothAdapter<'a> {
         ))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        let (vendor_id_source, _, _, _) = try!(self.get_modalias());
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
+        let (vendor_id_source, _, _, _) = self.get_modalias()?;
         Ok(vendor_id_source)
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        let (_, vendor_id, _, _) = try!(self.get_modalias());
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
+        let (_, vendor_id, _, _) = self.get_modalias()?;
         Ok(vendor_id)
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        let (_, _, product_id, _) = try!(self.get_modalias());
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
+        let (_, _, product_id, _) = self.get_modalias()?;
         Ok(product_id)
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        let (_, _, _, device_id) = try!(self.get_modalias());
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
+        let (_, _, _, device_id) = self.get_modalias()?;
         Ok(device_id)
     }
 
@@ -253,17 +253,17 @@ impl<'a> BluetoothAdapter<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n12
-    pub fn start_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn start_discovery(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from("Deprecated, use Discovery Session"))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n27
-    pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn stop_discovery(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from("Deprecated, use Discovery Session"))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt#n40
-    pub fn remove_device(&self, device: String) -> Result<(), Box<Error>> {
+    pub fn remove_device(&self, device: String) -> Result<(), Box<dyn Error>> {
         self.call_method(
             "RemoveDevice",
             Some(&[MessageItem::ObjectPath(device.into())]),

--- a/src/bluetooth_device.rs
+++ b/src/bluetooth_device.rs
@@ -1,11 +1,11 @@
-use bluetooth_session::BluetoothSession;
-use bluetooth_utils;
+use crate::bluetooth_session::BluetoothSession;
+use crate::bluetooth_utils;
 use dbus::MessageItem;
 use hex::FromHex;
 use std::collections::HashMap;
 use std::error::Error;
 
-static DEVICE_INTERFACE: &'static str = "org.bluez.Device1";
+static DEVICE_INTERFACE: &str = "org.bluez.Device1";
 
 #[derive(Clone, Debug)]
 pub struct BluetoothDevice<'a> {
@@ -16,8 +16,8 @@ pub struct BluetoothDevice<'a> {
 impl<'a> BluetoothDevice<'a> {
     pub fn new(session: &'a BluetoothSession, object_path: String) -> BluetoothDevice {
         BluetoothDevice {
-            object_path: object_path,
-            session: session,
+            object_path,
+            session,
         }
     }
 
@@ -25,7 +25,7 @@ impl<'a> BluetoothDevice<'a> {
         self.object_path.clone()
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<dyn Error>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             DEVICE_INTERFACE,
@@ -34,7 +34,7 @@ impl<'a> BluetoothDevice<'a> {
         )
     }
 
-    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<Error>>
+    fn set_property<T>(&self, prop: &str, value: T, timeout_ms: i32) -> Result<(), Box<dyn Error>>
     where
         T: Into<MessageItem>,
     {
@@ -53,7 +53,7 @@ impl<'a> BluetoothDevice<'a> {
         method: &str,
         param: Option<&[MessageItem]>,
         timeout_ms: i32,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             DEVICE_INTERFACE,
@@ -68,38 +68,38 @@ impl<'a> BluetoothDevice<'a> {
      * Properties
      */
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n105
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
-        let address = try!(self.get_property("Address"));
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
+        let address = self.get_property("Address")?;
         Ok(String::from(address.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n109
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
-        let name = try!(self.get_property("Name"));
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
+        let name = self.get_property("Name")?;
         Ok(String::from(name.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n121
-    pub fn get_icon(&self) -> Result<String, Box<Error>> {
-        let icon = try!(self.get_property("Icon"));
+    pub fn get_icon(&self) -> Result<String, Box<dyn Error>> {
+        let icon = self.get_property("Icon")?;
         Ok(String::from(icon.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n126
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
-        let class = try!(self.get_property("Class"));
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
+        let class = self.get_property("Class")?;
         Ok(class.inner::<u32>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n126
-    pub fn get_appearance(&self) -> Result<u16, Box<Error>> {
-        let appearance = try!(self.get_property("Appearance"));
+    pub fn get_appearance(&self) -> Result<u16, Box<dyn Error>> {
+        let appearance = self.get_property("Appearance")?;
         Ok(appearance.inner::<u16>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n134
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-        let uuids = try!(self.get_property("UUIDs"));
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
+        let uuids = self.get_property("UUIDs")?;
         let z: &[MessageItem] = uuids.inner().unwrap();
         let mut v: Vec<String> = Vec::new();
         for y in z {
@@ -109,14 +109,14 @@ impl<'a> BluetoothDevice<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n139
-    pub fn is_paired(&self) -> Result<bool, Box<Error>> {
-        let paired = try!(self.get_property("Paired"));
+    pub fn is_paired(&self) -> Result<bool, Box<dyn Error>> {
+        let paired = self.get_property("Paired")?;
         Ok(paired.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n143
-    pub fn is_connected(&self) -> Result<bool, Box<Error>> {
-        let connected = try!(self.get_property("Connected"));
+    pub fn is_connected(&self) -> Result<bool, Box<dyn Error>> {
+        let connected = self.get_property("Connected")?;
         Ok(connected.inner::<bool>().unwrap())
     }
 
@@ -133,50 +133,50 @@ impl<'a> BluetoothDevice<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n149
-    pub fn set_trusted(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_trusted(&self, value: bool) -> Result<(), Box<dyn Error>> {
         self.set_property("Trusted", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n149
-    pub fn is_trusted(&self) -> Result<bool, Box<Error>> {
-        let trusted = try!(self.get_property("Trusted"));
+    pub fn is_trusted(&self) -> Result<bool, Box<dyn Error>> {
+        let trusted = self.get_property("Trusted")?;
         Ok(trusted.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n154
-    pub fn is_blocked(&self) -> Result<bool, Box<Error>> {
-        let blocked = try!(self.get_property("Blocked"));
+    pub fn is_blocked(&self) -> Result<bool, Box<dyn Error>> {
+        let blocked = self.get_property("Blocked")?;
         Ok(blocked.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n161
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
-        let alias = try!(self.get_property("Alias"));
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
+        let alias = self.get_property("Alias")?;
         Ok(String::from(alias.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n161
-    pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, value: String) -> Result<(), Box<dyn Error>> {
         self.set_property("Alias", value, 1000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n174
-    pub fn get_adapter(&self) -> Result<String, Box<Error>> {
-        let adapter = try!(self.get_property("Adapter"));
+    pub fn get_adapter(&self) -> Result<String, Box<dyn Error>> {
+        let adapter = self.get_property("Adapter")?;
         Ok(String::from(adapter.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n178
-    pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
-        let legacy_pairing = try!(self.get_property("LegacyPairing"));
+    pub fn is_legacy_pairing(&self) -> Result<bool, Box<dyn Error>> {
+        let legacy_pairing = self.get_property("LegacyPairing")?;
         Ok(legacy_pairing.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n189
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        let modalias = try!(self.get_property("Modalias"));
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
+        let modalias = self.get_property("Modalias")?;
         let m = modalias.inner::<&str>().unwrap();
-        let ids: Vec<&str> = m.split(":").collect();
+        let ids: Vec<&str> = m.split(':').collect();
 
         let source = String::from(ids[0]);
         let vendor = Vec::from_hex(ids[1][1..5].to_string()).unwrap();
@@ -191,41 +191,41 @@ impl<'a> BluetoothDevice<'a> {
         ))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        let (vendor_id_source, _, _, _) = try!(self.get_modalias());
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
+        let (vendor_id_source, _, _, _) = self.get_modalias()?;
         Ok(vendor_id_source)
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        let (_, vendor_id, _, _) = try!(self.get_modalias());
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
+        let (_, vendor_id, _, _) = self.get_modalias()?;
         Ok(vendor_id)
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        let (_, _, product_id, _) = try!(self.get_modalias());
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
+        let (_, _, product_id, _) = self.get_modalias()?;
         Ok(product_id)
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        let (_, _, _, device_id) = try!(self.get_modalias());
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
+        let (_, _, _, device_id) = self.get_modalias()?;
         Ok(device_id)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n194
-    pub fn get_rssi(&self) -> Result<i16, Box<Error>> {
-        let rssi = try!(self.get_property("RSSI"));
+    pub fn get_rssi(&self) -> Result<i16, Box<dyn Error>> {
+        let rssi = self.get_property("RSSI")?;
         Ok(rssi.inner::<i16>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n199
-    pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
-        let tx_power = try!(self.get_property("TxPower"));
+    pub fn get_tx_power(&self) -> Result<i16, Box<dyn Error>> {
+        let tx_power = self.get_property("TxPower")?;
         Ok(tx_power.inner::<i16>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n204
-    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<Error>> {
-        let manufacturer_data_array = try!(self.get_property("ManufacturerData"));
+    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<dyn Error>> {
+        let manufacturer_data_array = self.get_property("ManufacturerData")?;
         let mut m = HashMap::new();
         let dict_vec = manufacturer_data_array
             .inner::<&Vec<MessageItem>>()
@@ -237,7 +237,7 @@ impl<'a> BluetoothDevice<'a> {
                 .unwrap()
                 .inner::<&Vec<MessageItem>>()
                 .unwrap()
-                .into_iter()
+                .iter()
                 .map(|b| b.inner::<u8>().unwrap_or(0))
                 .collect();
             m.insert(key.inner::<u16>().unwrap(), v);
@@ -246,8 +246,8 @@ impl<'a> BluetoothDevice<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n210
-    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<Error>> {
-        let service_data_array = try!(self.get_property("ServiceData"));
+    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<dyn Error>> {
+        let service_data_array = self.get_property("ServiceData")?;
         let mut m = HashMap::new();
         let dict_vec = service_data_array.inner::<&Vec<MessageItem>>().unwrap();
         for dict in dict_vec {
@@ -257,7 +257,7 @@ impl<'a> BluetoothDevice<'a> {
                 .unwrap()
                 .inner::<&Vec<MessageItem>>()
                 .unwrap()
-                .into_iter()
+                .iter()
                 .map(|b| b.inner::<u8>().unwrap_or(0))
                 .collect();
             m.insert(key.inner::<&str>().unwrap().to_string(), v);
@@ -266,7 +266,7 @@ impl<'a> BluetoothDevice<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n215
-    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<dyn Error>> {
         bluetooth_utils::list_services(self.session.get_connection(), &self.object_path)
     }
 
@@ -275,32 +275,32 @@ impl<'a> BluetoothDevice<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n12
-    pub fn connect(&self, timeout_ms: i32) -> Result<(), Box<Error>> {
+    pub fn connect(&self, timeout_ms: i32) -> Result<(), Box<dyn Error>> {
         self.call_method("Connect", None, timeout_ms)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n29
-    pub fn disconnect(&self) -> Result<(), Box<Error>> {
+    pub fn disconnect(&self) -> Result<(), Box<dyn Error>> {
         self.call_method("Disconnect", None, 5000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n43
-    pub fn connect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn connect_profile(&self, uuid: String) -> Result<(), Box<dyn Error>> {
         self.call_method("ConnectProfile", Some(&[uuid.into()]), 30000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n55
-    pub fn disconnect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn disconnect_profile(&self, uuid: String) -> Result<(), Box<dyn Error>> {
         self.call_method("DisconnectProfile", Some(&[uuid.into()]), 5000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n70
-    pub fn pair(&self) -> Result<(), Box<Error>> {
+    pub fn pair(&self) -> Result<(), Box<dyn Error>> {
         self.call_method("Pair", None, 60000)
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n97
-    pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
+    pub fn cancel_pairing(&self) -> Result<(), Box<dyn Error>> {
         self.call_method("CancelPairing", None, 5000)
     }
 }

--- a/src/bluetooth_event.rs
+++ b/src/bluetooth_event.rs
@@ -33,7 +33,7 @@ pub enum BluetoothEvent {
 impl BluetoothEvent {
     pub fn from(conn_msg: Message) -> Option<BluetoothEvent> {
         let result: Result<
-            (&str, HashMap<String, Variant<Box<RefArg>>>),
+            (&str, HashMap<String, Variant<Box<dyn RefArg>>>),
             TypeMismatchError,
         > = conn_msg.read2();
 

--- a/src/bluetooth_gatt_descriptor.rs
+++ b/src/bluetooth_gatt_descriptor.rs
@@ -1,11 +1,11 @@
-use bluetooth_session::BluetoothSession;
-use bluetooth_utils;
+use crate::bluetooth_session::BluetoothSession;
+use crate::bluetooth_utils;
 use dbus::{BusType, Connection, Message, MessageItem, MessageItemArray, Signature};
 
 use std::error::Error;
 
-static SERVICE_NAME: &'static str = "org.bluez";
-static GATT_DESCRIPTOR_INTERFACE: &'static str = "org.bluez.GattDescriptor1";
+static SERVICE_NAME: &str = "org.bluez";
+static GATT_DESCRIPTOR_INTERFACE: &str = "org.bluez.GattDescriptor1";
 
 #[derive(Clone, Debug)]
 pub struct BluetoothGATTDescriptor<'a> {
@@ -16,8 +16,8 @@ pub struct BluetoothGATTDescriptor<'a> {
 impl<'a> BluetoothGATTDescriptor<'a> {
     pub fn new(session: &'a BluetoothSession, object_path: String) -> BluetoothGATTDescriptor {
         BluetoothGATTDescriptor {
-            object_path: object_path,
-            session: session,
+            object_path,
+            session,
         }
     }
 
@@ -25,7 +25,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
         self.object_path.clone()
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<dyn Error>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             GATT_DESCRIPTOR_INTERFACE,
@@ -39,7 +39,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
         method: &str,
         param: Option<&[MessageItem]>,
         timeout_ms: i32,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         bluetooth_utils::call_method(
             self.session.get_connection(),
             GATT_DESCRIPTOR_INTERFACE,
@@ -55,20 +55,20 @@ impl<'a> BluetoothGATTDescriptor<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n198
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
-        let uuid = try!(self.get_property("UUID"));
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
+        let uuid = self.get_property("UUID")?;
         Ok(String::from(uuid.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n202
-    pub fn get_characteristic(&self) -> Result<String, Box<Error>> {
-        let service = try!(self.get_property("Characteristic"));
+    pub fn get_characteristic(&self) -> Result<String, Box<dyn Error>> {
+        let service = self.get_property("Characteristic")?;
         Ok(String::from(service.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n207
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
-        let value = try!(self.get_property("Value"));
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
+        let value = self.get_property("Value")?;
         let z: &[MessageItem] = value.inner().unwrap();
         let mut v: Vec<u8> = Vec::new();
         for y in z {
@@ -78,8 +78,8 @@ impl<'a> BluetoothGATTDescriptor<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n213
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
-        let flags = try!(self.get_property("Flags"));
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
+        let flags = self.get_property("Flags")?;
         let z: &[MessageItem] = flags.inner().unwrap();
         let mut v: Vec<String> = Vec::new();
         for y in z {
@@ -93,14 +93,14 @@ impl<'a> BluetoothGATTDescriptor<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n174
-    pub fn read_value(&self, offset: Option<u16>) -> Result<Vec<u8>, Box<Error>> {
-        let c = try!(Connection::get_private(BusType::System));
-        let mut m = try!(Message::new_method_call(
+    pub fn read_value(&self, offset: Option<u16>) -> Result<Vec<u8>, Box<dyn Error>> {
+        let c = Connection::get_private(BusType::System)?;
+        let mut m = Message::new_method_call(
             SERVICE_NAME,
             &self.object_path,
             GATT_DESCRIPTOR_INTERFACE,
             "ReadValue"
-        ));
+        )?;
         m.append_items(&[MessageItem::Array(
             MessageItemArray::new(
                 match offset {
@@ -113,7 +113,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
                 Signature::from("a{sv}"),
             ).unwrap(),
         )]);
-        let reply = try!(c.send_with_reply_and_block(m, 1000));
+        let reply = c.send_with_reply_and_block(m, 1000)?;
         let items: MessageItem = reply.get1().unwrap();
         let z: &[MessageItem] = items.inner().unwrap();
         let mut v: Vec<u8> = Vec::new();
@@ -124,7 +124,7 @@ impl<'a> BluetoothGATTDescriptor<'a> {
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n186
-    pub fn write_value(&self, values: Vec<u8>, offset: Option<u16>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, values: Vec<u8>, offset: Option<u16>) -> Result<(), Box<dyn Error>> {
         let args = {
             let mut res: Vec<MessageItem> = Vec::new();
             for v in values {

--- a/src/bluetooth_gatt_service.rs
+++ b/src/bluetooth_gatt_service.rs
@@ -1,10 +1,10 @@
-use bluetooth_session::BluetoothSession;
-use bluetooth_utils;
+use crate::bluetooth_session::BluetoothSession;
+use crate::bluetooth_utils;
 use dbus::MessageItem;
 
 use std::error::Error;
 
-static GATT_SERVICE_INTERFACE: &'static str = "org.bluez.GattService1";
+static GATT_SERVICE_INTERFACE: &str = "org.bluez.GattService1";
 
 #[derive(Clone, Debug)]
 pub struct BluetoothGATTService<'a> {
@@ -15,8 +15,8 @@ pub struct BluetoothGATTService<'a> {
 impl<'a> BluetoothGATTService<'a> {
     pub fn new(session: &'a BluetoothSession, object_path: String) -> BluetoothGATTService {
         BluetoothGATTService {
-            object_path: object_path,
-            session: session,
+            object_path,
+            session,
         }
     }
 
@@ -24,7 +24,7 @@ impl<'a> BluetoothGATTService<'a> {
         self.object_path.clone()
     }
 
-    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<Error>> {
+    fn get_property(&self, prop: &str) -> Result<MessageItem, Box<dyn Error>> {
         bluetooth_utils::get_property(
             self.session.get_connection(),
             GATT_SERVICE_INTERFACE,
@@ -38,29 +38,29 @@ impl<'a> BluetoothGATTService<'a> {
      */
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n33
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
-        let uuid = try!(self.get_property("UUID"));
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
+        let uuid = self.get_property("UUID")?;
         Ok(String::from(uuid.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n37
-    pub fn is_primary(&self) -> Result<bool, Box<Error>> {
-        let primary = try!(self.get_property("Primary"));
+    pub fn is_primary(&self) -> Result<bool, Box<dyn Error>> {
+        let primary = self.get_property("Primary")?;
         Ok(primary.inner::<bool>().unwrap())
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n42
-    pub fn get_device(&self) -> Result<String, Box<Error>> {
-        let device = try!(self.get_property("Device"));
+    pub fn get_device(&self) -> Result<String, Box<dyn Error>> {
+        let device = self.get_property("Device")?;
         Ok(String::from(device.inner::<&str>().unwrap()))
     }
 
     // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n48
-    pub fn get_includes(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_includes(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from("Not implemented"))
     }
 
-    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<dyn Error>> {
         bluetooth_utils::list_characteristics(self.session.get_connection(), &self.object_path)
     }
 }

--- a/src/bluetooth_obex.rs
+++ b/src/bluetooth_obex.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 use std::thread::sleep;
 use std::time::Duration;
 
-use bluetooth_device::BluetoothDevice;
-use bluetooth_session::BluetoothSession;
+use crate::bluetooth_device::BluetoothDevice;
+use crate::bluetooth_session::BluetoothSession;
 
 const OBEX_BUS: &str = "org.bluez.obex";
 const OBEX_PATH: &str = "/org/bluez/obex";
@@ -57,7 +57,7 @@ impl TransferState {
     }
 }
 
-pub fn open_bus_connection() -> Result<Connection, Box<Error>> {
+pub fn open_bus_connection() -> Result<Connection, Box<dyn Error>> {
     let c = Connection::get_private(BusType::Session)?;
     Ok(c)
 }
@@ -72,7 +72,7 @@ impl<'a> BluetoothOBEXSession<'a> {
     pub fn new(
         session: &'a BluetoothSession,
         device: &BluetoothDevice,
-    ) -> Result<BluetoothOBEXSession<'a>, Box<Error>> {
+    ) -> Result<BluetoothOBEXSession<'a>, Box<dyn Error>> {
         let device_address: String = device.get_address()?;
         let mut map = HashMap::new();
         map.insert("Target", Variant(SessionTarget::Opp.as_str()));
@@ -93,7 +93,7 @@ impl<'a> BluetoothOBEXSession<'a> {
     }
 
     // https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/obex-api.txt#n35
-    pub fn remove_session(&self) -> Result<(), Box<Error>> {
+    pub fn remove_session(&self) -> Result<(), Box<dyn Error>> {
         let object_path = ObjectPath::new(self.object_path.as_bytes())?;
         let m = Message::new_method_call(OBEX_BUS, OBEX_PATH, CLIENT_INTERFACE, "RemoveSession")?
             .append1(object_path);
@@ -116,7 +116,7 @@ impl<'a> BluetoothOBEXTransfer<'a> {
     pub fn send_file(
         session: &'a BluetoothOBEXSession,
         file_path: &str,
-    ) -> Result<BluetoothOBEXTransfer<'a>, Box<Error>> {
+    ) -> Result<BluetoothOBEXTransfer<'a>, Box<dyn Error>> {
         let session_path: String = session.object_path.clone();
         let m =
             Message::new_method_call(OBEX_BUS, session_path, OBJECT_PUSH_INTERFACE, "SendFile")?
@@ -142,7 +142,7 @@ impl<'a> BluetoothOBEXTransfer<'a> {
     }
 
     // https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/obex-api.txt#n115
-    pub fn status(&self) -> Result<String, Box<Error>> {
+    pub fn status(&self) -> Result<String, Box<dyn Error>> {
         let transfer_path = self.object_path.clone();
         let p = Props::new(
             &self.session.session.get_connection(),
@@ -158,7 +158,7 @@ impl<'a> BluetoothOBEXTransfer<'a> {
         }
     }
 
-    pub fn wait_until_transfer_completed(&self) -> Result<(), Box<Error>> {
+    pub fn wait_until_transfer_completed(&self) -> Result<(), Box<dyn Error>> {
         sleep(Duration::from_millis(500));
         let mut transfer_status: String = self.status()?;
 

--- a/src/bluetooth_session.rs
+++ b/src/bluetooth_session.rs
@@ -2,7 +2,7 @@ use dbus::{BusType, ConnMsgs, Connection};
 
 use std::error::Error;
 
-static BLUEZ_MATCH: &'static str = "type='signal',sender='org.bluez'";
+static BLUEZ_MATCH: &str = "type='signal',sender='org.bluez'";
 
 #[derive(Debug)]
 pub struct BluetoothSession {
@@ -10,7 +10,7 @@ pub struct BluetoothSession {
 }
 
 impl BluetoothSession {
-    pub fn create_session(path: Option<&str>) -> Result<BluetoothSession, Box<Error>> {
+    pub fn create_session(path: Option<&str>) -> Result<BluetoothSession, Box<dyn Error>> {
         let rule = {
             if let Some(path) = path {
                 format!("{},path='{}'", BLUEZ_MATCH, path)
@@ -19,14 +19,14 @@ impl BluetoothSession {
             }
         };
 
-        let c = try!(Connection::get_private(BusType::System));
+        let c = Connection::get_private(BusType::System)?;
         c.add_match(rule.as_str())?;
         Ok(BluetoothSession::new(c))
     }
 
     fn new(connection: Connection) -> BluetoothSession {
         BluetoothSession {
-            connection: connection,
+            connection,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,12 @@
-extern crate dbus;
-extern crate hex;
-
-pub use bluetooth_adapter::BluetoothAdapter;
-pub use bluetooth_device::BluetoothDevice;
-pub use bluetooth_discovery_session::BluetoothDiscoverySession;
-pub use bluetooth_event::BluetoothEvent;
-pub use bluetooth_gatt_characteristic::BluetoothGATTCharacteristic;
-pub use bluetooth_gatt_descriptor::BluetoothGATTDescriptor;
-pub use bluetooth_gatt_service::BluetoothGATTService;
-pub use bluetooth_obex::BluetoothOBEXSession;
-pub use bluetooth_session::BluetoothSession;
+pub use crate::bluetooth_adapter::BluetoothAdapter;
+pub use crate::bluetooth_device::BluetoothDevice;
+pub use crate::bluetooth_discovery_session::BluetoothDiscoverySession;
+pub use crate::bluetooth_event::BluetoothEvent;
+pub use crate::bluetooth_gatt_characteristic::BluetoothGATTCharacteristic;
+pub use crate::bluetooth_gatt_descriptor::BluetoothGATTDescriptor;
+pub use crate::bluetooth_gatt_service::BluetoothGATTService;
+pub use crate::bluetooth_obex::BluetoothOBEXSession;
+pub use crate::bluetooth_session::BluetoothSession;
 
 pub mod bluetooth_adapter;
 pub mod bluetooth_device;


### PR DESCRIPTION
Migrated the code to edition to 2018. Changes include:
* `try!(abc)` --> `abc?`
* `Box<X>` --> `Box<dyn X>`
* No need for extern crate 
* `use something_from_crate::ABC` --> `use crate::something_from_crate::ABC`
* `&String` --> `&str`
* Simplify some struct creations `ABC { x: x}` --> `ABC { x}`

Edit: I'm not sure if this necessitates a version bump, but this isn't actually changing any functionality